### PR TITLE
Use fetch API instead of request package

### DIFF
--- a/src/main/client/typescript.client.ftl
+++ b/src/main/client/typescript.client.ftl
@@ -23,12 +23,13 @@ import ClientResponse from "./ClientResponse";
 
 export class FusionAuthClient {
   public clientBuilder: IRESTClientBuilder = new DefaultRESTClientBuilder();
+  public credentials: RequestCredentials;
 
-  constructor(public apiKey: string, public host: string, public tenantId?: string) {
-    this.apiKey = apiKey;
-    this.host = host;
-    this.tenantId = tenantId;
-  }
+  constructor(
+    public apiKey: string,
+    public host: string,
+    public tenantId?: string,
+  ) { }
 
   /**
    * Sets the tenant id, that will be included in the X-FusionAuth-TenantId header.
@@ -36,8 +37,19 @@ export class FusionAuthClient {
    * @param {string | null} tenantId The value of the X-FusionAuth-TenantId header.
    * @returns {FusionAuthClient}
    */
-  setTenantId(tenantId: string | null) {
+  setTenantId(tenantId: string | null): FusionAuthClient {
     this.tenantId = tenantId;
+    return this;
+  }
+
+  /**
+   * Sets whether and how cookies will be sent with each request.
+   * 
+   * @param value The value that indicates whether and how cookies will be sent.
+   * @returns {FusionAuthClient}
+   */
+  setRequestCredentials(value: RequestCredentials): FusionAuthClient {
+    this.credentials = value;
     return this;
   }
 
@@ -94,8 +106,12 @@ export class FusionAuthClient {
   private start(): IRESTClient {
     let client = this.clientBuilder.build(this.host).withAuthorization(this.apiKey);
 
-    if (this.tenantId !== null && typeof(this.tenantId) !== 'undefined') {
+    if (this.tenantId != null) {
       client.withHeader('X-FusionAuth-TenantId', this.tenantId);
+    }
+
+    if (this.credentials != null) {
+      client.withCredentials(this.credentials);
     }
 
     return client;


### PR DESCRIPTION
credentials settings for fetchI added a function that would allow users of the client to set how they want cookies sent with in all requests.

I also added the return type to the previous function that was added, thanks @fdaugs and @robotdan for that!

Lastly, refactored the constructor which, when compiled, resulted in duplicate code.