### PR TITLE
Use API Key, support optional parameters and allow to check for success (HTTP 2xx)

### DIFF
--- a/src/main/client/go.client.ftl
+++ b/src/main/client/go.client.ftl
@@ -33,10 +33,10 @@ import (
 // URIWithSegment returns a string with a "/" delimiter between the uri and segment
 // If segment is not set (""), just the uri is returned
 func URIWithSegment(uri, segment string) string {
-  if segment == "" {
-    return uri
-  }
-  return uri + "/" + segment
+	if segment == "" {
+		return uri
+	}
+	return uri + "/" + segment
 }
 
 // NewRequest creates a new request for the FusionAuth API call
@@ -55,8 +55,8 @@ func (c *FusionAuthClient) NewRequest(method, endpoint string, body interface{})
 	if err != nil {
 		return nil, err
 	}
-  if c.APIKey != "" {
-    // Send the API Key, but only if it is set
+	if c.APIKey != "" {
+		// Send the API Key, but only if it is set
 		req.Header.Set("Authorization", c.APIKey)
 	}
 	req.Header.Set("Accept", "application/json")
@@ -73,9 +73,9 @@ func (c *FusionAuthClient) Do(req *http.Request, v interface{}) (*http.Response,
 	responseDump, _ := httputil.DumpResponse(resp, true)
 	fmt.Println(string(responseDump))
 	err = json.NewDecoder(resp.Body).Decode(v)
-  if err == nil && (resp.StatusCode < 200 || resp.StatusCode > 299) {
-    // If everything went well but the API responded with something other than HTTP 2xx, we raise an error
-    // That way, consumers can check for ErrRequestUnsuccessful
+	if err == nil && (resp.StatusCode < 200 || resp.StatusCode > 299) {
+		// If everything went well but the API responded with something other than HTTP 2xx, we raise an error
+		// That way, consumers can check for ErrRequestUnsuccessful
 		return resp, ErrRequestUnsuccessful
 	}
 	return resp, err

--- a/src/main/client/go.client.ftl
+++ b/src/main/client/go.client.ftl
@@ -21,6 +21,7 @@ import (
   "bytes"
   "encoding/base64"
   "encoding/json"
+  "errors"
   "fmt"
   "io"
   "net/http"
@@ -29,6 +30,8 @@ import (
   "strconv"
   "strings"
 )
+
+var ErrRequestUnsuccessful = errors.New("Response from FusionAuth API was not successful")
 
 // URIWithSegment returns a string with a "/" delimiter between the uri and segment
 // If segment is not set (""), just the uri is returned


### PR DESCRIPTION
Simple and non-invasive "solutions" for the first 3 bullets of https://github.com/FusionAuth/fusionauth-go-client/issues/8