### PR TITLE
Adds a default timeout

### DIFF
--- a/src/main/client/go.client.ftl
+++ b/src/main/client/go.client.ftl
@@ -34,12 +34,15 @@ import (
 // if httpClient is nil then a DefaultClient is used
 func NewClient(httpClient *http.Client, baseURL *url.URL, apiKey string) *FusionAuthClient {
   if httpClient == nil {
-    httpClient = http.DefaultClient
+    httpClient = &http.Client{
+      Timeout: 5 * time.Minute,
+    }
   }
   c := &FusionAuthClient{
     HTTPClient: httpClient,
     BaseURL:    baseURL,
-    APIKey:     apiKey}
+    APIKey:     apiKey,
+  }
 
   return c
 }


### PR DESCRIPTION
If a default http client is used in place of a provided one, you might want to ensure that it has a timeout. `http.DefaultClient` has no timeout, and under certain events could possibly deadlock. There are one or two other things that should probably be touched up, but this one sticks out to me the most.

While I put in 5 minutes, feel free to change it to however long you think is appropriate for a default.