### PR TITLE
Added interface and extension methods to netcore

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -122,6 +122,10 @@ target(name: "build-csharp", description: "Build the C# Client Library") {
 }
 
 target(name: "build-netcore", description: "Build the C# .netCore Client Library") {
+  clientLibrary.buildClient(template: "src/main/client/netcore.client.interface.ftl",
+                            outputFile: "../fusionauth-netcore-client/fusionauth-netcore-client/src/io/fusionauth/IFusionAuthClient.cs")
+  clientLibrary.buildClient(template: "src/main/client/netcore.client.extensions.ftl",
+                            outputFile: "../fusionauth-netcore-client/fusionauth-netcore-client/src/io/fusionauth/FusionAuthClientExtensions.cs")
   clientLibrary.buildClient(template: "src/main/client/netcore.client.ftl",
                             outputFile: "../fusionauth-netcore-client/fusionauth-netcore-client/src/io/fusionauth/FusionAuthClient.cs")
   file.delete {

--- a/src/main/client/netcore.client.extensions.ftl
+++ b/src/main/client/netcore.client.extensions.ftl
@@ -1,0 +1,75 @@
+[#import "_macros.ftl" as global/]
+[#function removeConstantParams params]
+  [#local result = []]
+  [#list params![] as param]
+    [#if !param.constant??]
+      [#local result = result + [param]/]
+    [/#if]
+  [/#list]
+  [#return result/]
+[/#function]
+[#function getParamNames params]
+  [#local result = []]
+  [#list params as param]
+    [#local result = result + [param.name]/]
+  [/#list]
+  [#return result?join(", ")/]
+[/#function]
+/*
+ * Copyright (c) 2018-2020, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using io.fusionauth.domain;
+using io.fusionauth.domain.api;
+using io.fusionauth.domain.api.email;
+using io.fusionauth.domain.api.identityProvider;
+using io.fusionauth.domain.api.jwt;
+using io.fusionauth.domain.api.passwordless;
+using io.fusionauth.domain.api.report;
+using io.fusionauth.domain.api.twoFactor;
+using io.fusionauth.domain.api.user;
+using io.fusionauth.domain.oauth2;
+
+namespace io.fusionauth {
+  public static class FusionAuthClientExtensions {
+    [#list apis as api]
+		[#assign params = removeConstantParams(api.params![])]
+
+    /// <summary>
+      [#list api.comments as comment]
+    /// ${comment}
+      [/#list]
+    /// </summary>
+    /// <param name="client">The <see cref="IFusionAuthClient"> to extend.</param>
+      [#list params as param]
+    /// <param name="${param.name}"> ${param.comments?join("\n     /// ")}</param>
+      [/#list]
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+     [#if api.deprecated??]
+    [Obsolete("${api.deprecated?replace("{{renamedMethod}}", (api.renamedMethod!'')?cap_first)}")]
+     [/#if]
+    public static ClientResponse<${global.convertType(api.successResponse, "csharp")}> ${api.methodName?cap_first}(this IFusionAuthClient client[#if params?size > 0], [/#if]${global.methodParameters(api, "csharp")}) {
+      return client.${api.methodName?cap_first}Async(${getParamNames(params)}).GetAwaiter().GetResult();
+    }
+    [/#list]
+  }
+}

--- a/src/main/client/netcore.client.ftl
+++ b/src/main/client/netcore.client.ftl
@@ -15,16 +15,6 @@
  * language governing permissions and limitations under the License.
  */
 
-[#function paramNames api]
-  [#local result = []]
-  [#list api.params![] as param]
-    [#if !param.constant??]
-      [#local result = result + [param.name]/]
-    [/#if]
-  [/#list]
-  [#return result?join(", ")/]
-[/#function]
-
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -41,7 +31,7 @@ using io.fusionauth.domain.api.user;
 using io.fusionauth.domain.oauth2;
 
 namespace io.fusionauth {
-  public class FusionAuthClient {
+  public class FusionAuthClient : IFusionAuthClient {
     public readonly string apiKey;
 
     public readonly string host;
@@ -73,21 +63,7 @@ namespace io.fusionauth {
     }
     [#list apis as api]
 
-    /// <summary>
-      [#list api.comments as comment]
-    /// ${comment}
-      [/#list]
-    /// This is an asynchronous method.
-    /// </summary>
-      [#list api.params![] as param]
-        [#if !param.constant??]
-    /// <param name="${param.name}"> ${param.comments?join("\n    /// ")}</param>
-        [/#if]
-      [/#list]
-    /// <returns>When successful, the response will contain the log of the action. If there was a validation error or any
-    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
-    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
-    /// IOException.</returns>
+    /// <inheritdoc/>
      [#if api.deprecated??]
     [Obsolete("${api.deprecated?replace("{{renamedMethod}}",(api.renamedMethod!'')?cap_first + "Async")}")]
      [/#if]
@@ -124,27 +100,6 @@ namespace io.fusionauth {
       [/#if]
           .withMethod("${api.method?cap_first}")
           .goAsync<${global.convertType(api.successResponse, "csharp")}>();
-    }
-		
-    /// <summary>
-      [#list api.comments as comment]
-    /// ${comment}
-      [/#list]
-    /// </summary>
-      [#list api.params![] as param]
-        [#if !param.constant??]
-    /// <param name="${param.name}"> ${param.comments?join("\n     /// ")}</param>
-        [/#if]
-      [/#list]
-    /// <returns>When successful, the response will contain the log of the action. If there was a validation error or any
-    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
-    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
-    /// IOException.</returns>
-     [#if api.deprecated??]
-    [Obsolete("${api.deprecated?replace("{{renamedMethod}}", (api.renamedMethod!'')?cap_first)}")]
-     [/#if]
-    public ClientResponse<${global.convertType(api.successResponse, "csharp")}> ${api.methodName?cap_first}(${global.methodParameters(api, "csharp")}) {
-      return ${api.methodName?cap_first}Async(${paramNames(api)}).GetAwaiter().GetResult();
     }
     [/#list]
   }

--- a/src/main/client/netcore.client.interface.ftl
+++ b/src/main/client/netcore.client.interface.ftl
@@ -1,0 +1,59 @@
+[#import "_macros.ftl" as global/]
+/*
+ * Copyright (c) 2018-2020, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using io.fusionauth.domain;
+using io.fusionauth.domain.api;
+using io.fusionauth.domain.api.email;
+using io.fusionauth.domain.api.identityProvider;
+using io.fusionauth.domain.api.jwt;
+using io.fusionauth.domain.api.passwordless;
+using io.fusionauth.domain.api.report;
+using io.fusionauth.domain.api.twoFactor;
+using io.fusionauth.domain.api.user;
+using io.fusionauth.domain.oauth2;
+
+namespace io.fusionauth {
+  public interface IFusionAuthClient {
+    [#list apis as api]
+
+    /// <summary>
+      [#list api.comments as comment]
+    /// ${comment}
+      [/#list]
+    /// This is an asynchronous method.
+    /// </summary>
+      [#list api.params![] as param]
+        [#if !param.constant??]
+    /// <param name="${param.name}"> ${param.comments?join("\n    /// ")}</param>
+        [/#if]
+      [/#list]
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+     [#if api.deprecated??]
+    [Obsolete("${api.deprecated?replace("{{renamedMethod}}",(api.renamedMethod!'')?cap_first + "Async")}")]
+     [/#if]
+    Task<ClientResponse<${global.convertType(api.successResponse, "csharp")}>> ${api.methodName?cap_first}Async(${global.methodParameters(api, "csharp")});
+    [/#list]
+  }
+}


### PR DESCRIPTION
Added additional templates which will generate the IFusionAuthClient interface and an extra FusionAuthExtensions class. This will keep the code better separated.

Changes:

- The interface itself only contains a description of the async functions and the documentation. This interface allows easier mocking and unit testing. 
- The class only implements the async functions (sync methods are moved). Documentation is inherited from the interface.
- The extensions class continues support for the synchronous functions, which was previously added to the FusionAuthClient class.

The compiled code works just the same like before. 