### PR TITLE
Includes refreshToken as optional parameter for IssueJWT 

### DIFF
--- a/src/main/api/issueJWT.json
+++ b/src/main/api/issueJWT.json
@@ -29,6 +29,16 @@
       ],
       "type": "notUsed",
       "javaType": "String"
+    },
+    {
+      "name": "refreshToken",
+      "comments": [
+        "(Optional) An existing refresh token used to request a refresh token in addition to a JWT in the response.",
+        "<p>The target application represented by the applicationid request parameter must have refresh ",
+        "tokens enabled in order to receive a refresh token in the response.</p>"
+      ],
+      "type": "urlParameter",
+      "javaType": "String"
     }
   ]
 }


### PR DESCRIPTION
https://fusionauth.io/docs/v1/tech/apis/jwt#issue-a-jwt

As described in the docs above, 
If a user wants to login from Application A to Application B, they can provide an AccessToken for Application A and expect an accessToken for Application B. 

If a refresh token for Application A is provided, a refreshToken for Application B is also provided.

