### PR TITLE
fix: define string values for enums

### DIFF
--- a/src/main/client/typescript.client.ftl
+++ b/src/main/client/typescript.client.ftl
@@ -183,7 +183,7 @@ export enum ${d.type} {
     [#if global.needsConverter(d)]
   ${value.name} = "${(value.args![])[0]!value.name}"[#sep],[/#sep]
     [#else]
-  ${value.name!value}[#sep],[/#sep]
+  ${value.name!value} = "${value.name!value}"[#sep],[/#sep]
     [/#if]
   [/#list]
 }


### PR DESCRIPTION
Defines default values for TypeScript enums.

See https://github.com/FusionAuth/fusionauth-typescript-client/pull/25

<hr>

I'm not sure how to test this, so I haven't. Just trying to help out where I can.