### PR TITLE
fix: io.EOF no longer a bad error for empty response

### DIFF
--- a/src/main/client/go.client.ftl
+++ b/src/main/client/go.client.ftl
@@ -118,7 +118,9 @@ func (rc *restClient) Do() error {
   } else {
     rc.ErrorRef = nil
     if _, ok := rc.ResponseRef.(*BaseHTTPResponse); !ok {
-      err = json.NewDecoder(resp.Body).Decode(rc.ResponseRef)
+      if err = json.NewDecoder(resp.Body).Decode(rc.ErrorRef); err == io.EOF {
+        err = nil
+      }
     }
   }
   rc.ResponseRef.(StatusAble).SetStatus(resp.StatusCode)


### PR DESCRIPTION
In the go library, empty response bodies return the `io.EOF`. This is graceful error, and could be returned as nil by the package.