### PR TITLE
[130] New Client Methods for Interacting with Message Templates APIs

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -21,7 +21,7 @@ javaErrorVersion = "2.2.2"
 /* Keep this at 3.4.0 for now to preserve the algorithms enum */
 fusionauthJWTVersion = "3.4.0"
 
-project(group: "io.fusionauth", name: "fusionauth-client-builder", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-client-builder", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -21,7 +21,7 @@ javaErrorVersion = "2.2.2"
 /* Keep this at 3.4.0 for now to preserve the algorithms enum */
 fusionauthJWTVersion = "3.4.0"
 
-project(group: "io.fusionauth", name: "fusionauth-client-builder", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-client-builder", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/src/main/api/createMessageTemplate.json
+++ b/src/main/api/createMessageTemplate.json
@@ -1,0 +1,28 @@
+{
+  "uri": "/api/message/template",
+  "comments": [
+    "Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated."
+  ],
+  "method": "post",
+  "methodName": "createMessageTemplate",
+  "successResponse": "MessageTemplateResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "messageTemplateId",
+      "comments": [
+        "(Optional) The Id for the template. If not provided a secure random UUID will be generated."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request object that contains all of the information used to create the message template."
+      ],
+      "type": "body",
+      "javaType": "MessageTemplateRequest"
+    }
+  ]
+}

--- a/src/main/api/deleteMessageTemplate.json
+++ b/src/main/api/deleteMessageTemplate.json
@@ -1,0 +1,20 @@
+{
+  "uri": "/api/message/template",
+  "comments": [
+    "Deletes the message template for the given Id."
+  ],
+  "method": "delete",
+  "methodName": "deleteMessageTemplate",
+  "successResponse": "Void",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "messageTemplateId",
+      "comments": [
+        "The Id of the message template to delete."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    }
+  ]
+}

--- a/src/main/api/patchMessageTemplate.json
+++ b/src/main/api/patchMessageTemplate.json
@@ -1,0 +1,28 @@
+{
+  "uri": "/api/message/template",
+  "comments": [
+    "Updates, via PATCH, the message template with the given Id."
+  ],
+  "method": "patch",
+  "methodName": "patchMessageTemplate",
+  "successResponse": "MessageTemplateResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "messageTemplateId",
+      "comments": [
+        "The Id of the message template to update."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request that contains just the new message template information."
+      ],
+      "type": "body",
+      "javaType": "MessageTemplateRequest"
+    }
+  ]
+}

--- a/src/main/api/retrieveMessageTemplate.json
+++ b/src/main/api/retrieveMessageTemplate.json
@@ -1,0 +1,20 @@
+{
+  "uri": "/api/message/template",
+  "comments": [
+    "Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates."
+  ],
+  "method": "get",
+  "methodName": "retrieveMessageTemplate",
+  "successResponse": "MessageTemplateResponse",
+  "errorResponse": "Void",
+  "params": [
+    {
+      "name": "messageTemplateId",
+      "comments": [
+        "(Optional) The Id of the message template."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    }
+  ]
+}

--- a/src/main/api/retrieveMessageTemplatePreview.json
+++ b/src/main/api/retrieveMessageTemplatePreview.json
@@ -1,0 +1,20 @@
+{
+  "uri": "/api/message/template/preview",
+  "comments": [
+    "Creates a preview of the message template provided in the request, normalized to a given locale."
+  ],
+  "method": "post",
+  "methodName": "retrieveMessageTemplatePreview",
+  "successResponse": "PreviewMessageTemplateResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "request",
+      "comments": [
+        "The request that contains the email template and optionally a locale to render it in."
+      ],
+      "type": "body",
+      "javaType": "PreviewMessageTemplateRequest"
+    }
+  ]
+}

--- a/src/main/api/retrieveMessageTemplates.json
+++ b/src/main/api/retrieveMessageTemplates.json
@@ -1,0 +1,10 @@
+{
+  "uri": "/api/message/template",
+  "comments": [
+    "Retrieves all of the message templates."
+  ],
+  "method": "get",
+  "methodName": "retrieveMessageTemplates",
+  "successResponse": "MessageTemplateResponse",
+  "errorResponse": "Void"
+}

--- a/src/main/api/updateMessageTemplate.json
+++ b/src/main/api/updateMessageTemplate.json
@@ -1,0 +1,28 @@
+{
+  "uri": "/api/message/template",
+  "comments": [
+    "Updates the message template with the given Id."
+  ],
+  "method": "put",
+  "methodName": "updateMessageTemplate",
+  "successResponse": "MessageTemplateResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "messageTemplateId",
+      "comments": [
+        "The Id of the message template to update."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request that contains all of the new message template information."
+      ],
+      "type": "body",
+      "javaType": "MessageTemplateRequest"
+    }
+  ]
+}

--- a/src/main/client/android.client.ftl
+++ b/src/main/client/android.client.ftl
@@ -53,6 +53,8 @@ import io.fusionauth.domain.api.LoginResponse;
 import io.fusionauth.domain.api.MemberDeleteRequest;
 import io.fusionauth.domain.api.MemberRequest;
 import io.fusionauth.domain.api.MemberResponse;
+import io.fusionauth.domain.api.MessageTemplateRequest;
+import io.fusionauth.domain.api.MessageTemplateResponse;
 import io.fusionauth.domain.api.OAuthConfigurationResponse;
 import io.fusionauth.domain.api.PasswordValidationRulesResponse;
 import io.fusionauth.domain.api.PreviewRequest;

--- a/src/main/client/android.client.ftl
+++ b/src/main/client/android.client.ftl
@@ -57,6 +57,8 @@ import io.fusionauth.domain.api.MessageTemplateRequest;
 import io.fusionauth.domain.api.MessageTemplateResponse;
 import io.fusionauth.domain.api.OAuthConfigurationResponse;
 import io.fusionauth.domain.api.PasswordValidationRulesResponse;
+import io.fusionauth.domain.api.PreviewMessageTemplateRequest;
+import io.fusionauth.domain.api.PreviewMessageTemplateResponse;
 import io.fusionauth.domain.api.PreviewRequest;
 import io.fusionauth.domain.api.PreviewResponse;
 import io.fusionauth.domain.api.PublicKeyResponse;

--- a/src/main/client/java.client.ftl
+++ b/src/main/client/java.client.ftl
@@ -80,6 +80,8 @@ import io.fusionauth.domain.api.MessageTemplateResponse;
 import io.fusionauth.domain.api.OAuthConfigurationResponse;
 import io.fusionauth.domain.api.PasswordValidationRulesResponse;
 import io.fusionauth.domain.api.PendingResponse;
+import io.fusionauth.domain.api.PreviewMessageTemplateRequest;
+import io.fusionauth.domain.api.PreviewMessageTemplateResponse;
 import io.fusionauth.domain.api.PreviewRequest;
 import io.fusionauth.domain.api.PreviewResponse;
 import io.fusionauth.domain.api.PublicKeyResponse;

--- a/src/main/client/java.client.ftl
+++ b/src/main/client/java.client.ftl
@@ -75,6 +75,8 @@ import io.fusionauth.domain.api.LoginResponse;
 import io.fusionauth.domain.api.MemberDeleteRequest;
 import io.fusionauth.domain.api.MemberRequest;
 import io.fusionauth.domain.api.MemberResponse;
+import io.fusionauth.domain.api.MessageTemplateRequest;
+import io.fusionauth.domain.api.MessageTemplateResponse;
 import io.fusionauth.domain.api.OAuthConfigurationResponse;
 import io.fusionauth.domain.api.PasswordValidationRulesResponse;
 import io.fusionauth.domain.api.PendingResponse;

--- a/src/main/domain/io.fusionauth.domain.api.MessageTemplateRequest.json
+++ b/src/main/domain/io.fusionauth.domain.api.MessageTemplateRequest.json
@@ -1,0 +1,10 @@
+{
+  "packageName" : "io.fusionauth.domain.api",
+  "type" : "MessageTemplateRequest",
+  "description" : "/**\n * A Message Template Request to the API\n *\n * @author Michael Sleevi\n */\n",
+  "fields" : {
+    "messageTemplate" : {
+      "type" : "MessageTemplate"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.api.MessageTemplateResponse.json
+++ b/src/main/domain/io.fusionauth.domain.api.MessageTemplateResponse.json
@@ -1,0 +1,15 @@
+{
+  "packageName" : "io.fusionauth.domain.api",
+  "type" : "MessageTemplateResponse",
+  "fields" : {
+    "messageTemplate" : {
+      "type" : "MessageTemplate"
+    },
+    "messageTemplates" : {
+      "type" : "List",
+      "typeArguments" : [ {
+        "type" : "MessageTemplate"
+      } ]
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.api.PreviewMessageTemplateRequest.json
+++ b/src/main/domain/io.fusionauth.domain.api.PreviewMessageTemplateRequest.json
@@ -1,0 +1,13 @@
+{
+  "packageName" : "io.fusionauth.domain.api",
+  "type" : "PreviewMessageTemplateRequest",
+  "description" : "/**\n * @author Michael Sleevi\n */\n",
+  "fields" : {
+    "messageTemplate" : {
+      "type" : "MessageTemplate"
+    },
+    "locale" : {
+      "type" : "Locale"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.api.PreviewMessageTemplateResponse.json
+++ b/src/main/domain/io.fusionauth.domain.api.PreviewMessageTemplateResponse.json
@@ -1,0 +1,12 @@
+{
+  "packageName" : "io.fusionauth.domain.api",
+  "type" : "PreviewMessageTemplateResponse",
+  "fields" : {
+    "message" : {
+      "type" : "Message"
+    },
+    "errors" : {
+      "type" : "Errors"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.message.Message.json
+++ b/src/main/domain/io.fusionauth.domain.message.Message.json
@@ -1,0 +1,16 @@
+{
+  "packageName" : "io.fusionauth.domain.message",
+  "type" : "Message",
+  "description" : "/**\n * An incredible simplified view of a message\n *\n * @author Michael Sleevi\n */\n",
+  "implements" : [ {
+    "type" : "Buildable",
+    "typeArguments" : [ {
+      "type" : "Message"
+    } ]
+  } ],
+  "fields" : {
+    "text" : {
+      "type" : "String"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.message.MessageTemplate.json
+++ b/src/main/domain/io.fusionauth.domain.message.MessageTemplate.json
@@ -1,0 +1,31 @@
+{
+  "packageName" : "io.fusionauth.domain.message",
+  "type" : "MessageTemplate",
+  "description" : "/**\n * Stores an message template used to distribute messages;\n *\n * @author Michael Sleevi\n */\n",
+  "implements" : [ {
+    "type" : "Buildable",
+    "typeArguments" : [ {
+      "type" : "MessageTemplate"
+    } ]
+  } ],
+  "fields" : {
+    "defaultTemplate" : {
+      "type" : "String"
+    },
+    "id" : {
+      "type" : "UUID"
+    },
+    "insertInstant" : {
+      "type" : "ZonedDateTime"
+    },
+    "lastUpdateInstant" : {
+      "type" : "ZonedDateTime"
+    },
+    "localizedTemplates" : {
+      "type" : "LocalizedStrings"
+    },
+    "name" : {
+      "type" : "String"
+    }
+  }
+}


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`