### PR TITLE
Set changePassword as anonymous

### DIFF
--- a/src/main/api/changePassword.json
+++ b/src/main/api/changePassword.json
@@ -8,6 +8,7 @@
   "methodName": "changePassword",
   "successResponse": "ChangePasswordResponse",
   "errorResponse": "Errors",
+  "anonymous": true,
   "params": [
     {
       "name": "changePasswordId",


### PR DESCRIPTION
Per the request in the [PR](https://github.com/FusionAuth/fusionauth-typescript-client/pull/52) in fusionauth-typescript-client, I created a PR here.

Currently, the changePassword function (/src/FusionAuthClient.ts) uses the start function, which sends an Authorization header in the request with the api key.
However, according to the fusionauth docs, if a changePasswordId is sent, there is no need to send an api key.

In internal tests, it seems that this function is broken and fusionauth cannot accept an api key along with changePasswordId (fusionauth version 1.20.0).
When using this function, it sends the api key along with the changePasswordId, and the HTTP response status code was 401, which implies invalid Authorization header. When sending the exact same request without the Authorization header, the response status code was 200 and the password was successfully reset.

The fix is to use startAnonymous instead of start, to prevent sending the api key in the Authorization header, and instead only send the changePasswordId.