### PR TITLE
Fixed incorrect mapping for 'char' datatype.

### DIFF
--- a/src/main/client/_macros.ftl
+++ b/src/main/client/_macros.ftl
@@ -44,7 +44,7 @@
       [#return "nil"/]
     [#elseif type?starts_with("Collection")]
       [#return type?replace("Collection", "[]")?replace("UUID", "string")?replace("<", "")?replace(">", "")/]
-    [#elseif type == "String" || type = "UUID" || type == "ZoneId" || type == "URI" || type == "Locale" || type == "LocalDate"]
+    [#elseif type == "String" || type = "UUID" || type == "ZoneId" || type == "URI" || type == "Locale" || type == "LocalDate" || type == "char" ]
       [#return "string"/]
     [#elseif type == "Object" || type == "D" || type == "T"]
       [#return "interface{}"/]


### PR DESCRIPTION
Tested with local example.

This keeps the library from compiling (though the workaround is pretty easy).

Originally surfaced here: https://github.com/FusionAuth/go-client/issues/54