### PR TITLE
Handle special case for JWT object.

### DIFF
--- a/src/main/client/netcore.domain.ftl
+++ b/src/main/client/netcore.domain.ftl
@@ -106,8 +106,8 @@ namespace ${replaceKeywords(domain_item.packageName)} {
     private readonly Dictionary<string, dynamic> ${global.scrubName(replaceKeywords(fieldName))} = new Dictionary<string, dynamic>();
       [#else]
     [#if domain_item.type == "JWT" && domain_item.packageName == "io.fusionauth.jwt.domain" && field.type == "ZonedDateTime"]
-    // per https://github.com/FusionAuth/fusionauth-issues/issues/1362 JWT DateTimeOffsets need to be parsed as seconds, as opposed to milliseconds
-
+    [#-- per https://github.com/FusionAuth/fusionauth-issues/issues/1362 JWT DateTimeOffsets need to be parsed as seconds, as opposed to milliseconds 
+    --]
     [JsonConverter(typeof(DateTimeOffsetSecondsConverter))]
     [/#if]
     public [@printType field/] ${global.scrubName(replaceKeywords(fieldName))};


### PR DESCRIPTION
This object, and this object only, should use a special converter to handle the conversion from JSON, since the time claims here are in seconds, not milliseconds.

This makes the change I committed in this PR permanent:
https://github.com/FusionAuth/fusionauth-netcore-client/pull/49