### PR TITLE
feat: go: implements stringer interface for enums.

### DIFF
--- a/src/main/client/go.domain.ftl
+++ b/src/main/client/go.domain.ftl
@@ -136,6 +136,11 @@ func (b *${hackCollisions(d d.type)?cap_first}) SetStatus(status int) {
 [@addFunctions d.type/]
     [#elseif d.enum??]
 type ${d.type} string
+
+func (e ${d.type}) String() string {
+	return string(e)
+}
+
 const (
       [#list d.enum as value]
         [#if d.type == "EventType" || d.type == "GrantType"]


### PR DESCRIPTION
Being a lazy developer plugging into other systems (i.e. terraform) I want to be able to get string representations of enums, and IDE autocomplete using:
```go
fusionauth.GrantType_ClientCredentials.String()
```

Instead of having to manually typecast every enum:
```go
string(fusionauth.GrantType_ClientCredentials)
```

This will also enable being able to be a bit more smart enum based functions by being able to cast enums to the Stringer interface to do things over multiple types. As a trivial example:

```go
package main

import (
	"fmt"
	"strings"
)

type EventType string

func (e EventType) String() string {
	return string(e)
}

const (
	// ...
	EventType_UserUpdate                     EventType = "user.update"
	EventType_UserUpdateComplete             EventType = "user.update.complete"
	EventType_Test                           EventType = "test"
)

func enumsToStringList(enums ...fmt.Stringer) string {
	var enumStrArr []string
	for _, enum := range enums {
		enumStrArr = append(enumStrArr, enum.String())
	}

	return strings.Join(enumStrArr, ", ")
}

func main() {
	eventsList := enumsToStringList(
		EventType_UserUpdate,
		EventType_UserUpdateComplete,
		EventType_Test,
	)
	fmt.Printf("Enabled events: %s", eventsList)
}
```

_started from: https://github.com/FusionAuth/go-client/pull/59_