### PR TITLE
Openapi yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.iws
 **/.DS_Store
 build
+*.swp

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ fusionauth
 ├── fusionauth-java-client
 ├── fusionauth-javascript-client
 ├── fusionauth-node-client
+├── fusionauth-openapi
 ├── fusionauth-php-client
 ├── fusionauth-python-client
 ├── fusionauth-ruby-client
@@ -89,73 +90,3 @@ sb build-all
 For more information on the Savant build tool, checkout [savantbuild.org](http://savantbuild.org/).
 
 
-## OpenAPI support
-
-This is experimental.
-
-To build the YAML file:
-
-```
-cd bin && ruby ./build-openapi-yaml.rb
-```
-
-For options:
-
-```
-cd bin && ruby ./build-openapi-yaml.rb -h
-```
-
-To validate the YAML:
-
-```
-npm install -g @apidevtools/swagger-cli # one time
-swagger-cli validate openapi.yaml 
-```
-
-
-### Test the YAML
-
-```
-pip3 install schemathesis # one time
-schemathesis run -vvvv --checks not_a_server_error openapi.yaml --base-url http://localhost:9011 -H "Authorization: bf69486b-4733-4470-a592-f1bfce7af580" 
-```
-
-### Generate libraries
-
-Install either Swagger: https://github.com/swagger-api/swagger-codegen/ or openapi: https://github.com/OpenAPITools/openapi-generator
-
-Java
-
-```
-cd <dir>
-swagger-codegen generate  --group-id io.fusionauth --artifact-id fusionauth-client-library-codegen --artifact-version 1.0.2-SNAPSHOT --api-package io.fusionauth.codegen.api  --invoker-package io.fusionauth.codegen.invoker --model-package io.fusionauth.codegen.model -l java -o . -i ../fusionauth-client-builder/bin/openapi.yaml
-```
-
-Ruby
-```
-npx @openapitools/openapi-generator-cli generate -i ../fusionauth-client-builder/bin/openapi.yaml -g ruby -o . 
-```
-
-### TODO
-
-There are some flaws. While the specification is valid, the generated client libraries haven't been fully exercised.
-
-In particular:
-
-* polymorphic operations are not well supported by the client library generators. That means that identity provider requests and responses are not functional. I'm not sure if there are workarounds, but it seems like some work is being done. See https://github.com/swagger-api/swagger-codegen/issues/10011 for example.
-* this file is generated from the fusionauth-client-builder JSON files, not from code. This means that there may be gaps when compared to the REST API.
-* there's no information about what parameters are required or not, because that is not part of the API JSON files.
-* there are certain operations, status codes and security mechanisms (JWT auth, cookies for auth) that are not currently supported, again, because they are not included in the API JSON files.
-* oauth specific operations are not currently supported.
-
-Rollout plan:
-
-* Review with eng team, determine if current state is shippable to alpha users.
-* Ask folks who commened on https://github.com/FusionAuth/fusionauth-issues/issues/614 or otherwise expressed interest in this to kick the tires.
-* Determine what features need to be added to ship.
-* Fix any outstanding issues/add features.
-* Publish as 'tech preview' in docs. Close bugs for other SDKs.
-* Let it burn in for a few months, fix any issues.
-* Start publishing it as part of the release process. Maybe include it in the build? Maybe just on the download page.
-* Go back and provide specs for previous releases so that folks can use apidiff functionality.
-* Investigate bringing things closer to the code/fusionauth-app so that we don't need to maintain the API JSON files.

--- a/README.md
+++ b/README.md
@@ -87,3 +87,33 @@ sb build-all
 ```
 
 For more information on the Savant build tool, checkout [savantbuild.org](http://savantbuild.org/).
+
+
+## OpenAPI support
+
+This is experimental.
+
+To build the YAML file:
+
+`cd bin && ruby ./build-openapi-yaml.rb |tee openapi.yaml`
+
+To validate the YAML:
+
+```
+npm install -g @apidevtools/swagger-cli # one time
+swagger-cli validate openapi.yaml 
+```
+
+To test the YAML
+
+```
+pip3 install schemathesis # one time
+schemathesis run -vvvv --checks not_a_server_error openapi.yaml --base-url http://localhost:9011 -H "Authorization: bf69486b-4733-4470-a592-f1bfce7af580" 
+```
+
+To generate libraries:
+
+```
+cd <dir>
+swagger-codegen generate -i path/to/fusionauth-client-builder/bin/openapi.yaml -l java -o .
+```

--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ There are some flaws. While the specification is valid, the generated client lib
 In particular:
 
 * polymorphic operations are not well supported by the client library generators. That means that identity provider requests and responses are not functional. I'm not sure if there are workarounds, but it seems like some work is being done. See https://github.com/swagger-api/swagger-codegen/issues/10011 for example.
-* this file is generated from the client-builder JSON files, not from code. This means that there may be gaps when compared to the REST API.
-* there are certain operations, status codes and security mechanisms (JWT auth, cookies for auth) that are not currently supported. 
+* this file is generated from the fusionauth-client-builder JSON files, not from code. This means that there may be gaps when compared to the REST API.
+* there's no information about what parameters are required or not, because that is not part of the API JSON files.
+* there are certain operations, status codes and security mechanisms (JWT auth, cookies for auth) that are not currently supported, again, because they are not included in the API JSON files.
 * oauth specific operations are not currently supported.
 
 Rollout plan:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,15 @@ This is experimental.
 
 To build the YAML file:
 
-`cd bin && ruby ./build-openapi-yaml.rb |tee openapi.yaml`
+```
+cd bin && ruby ./build-openapi-yaml.rb
+```
+
+For options:
+
+```
+cd bin && ruby ./build-openapi-yaml.rb -h
+```
 
 To validate the YAML:
 
@@ -104,16 +112,49 @@ npm install -g @apidevtools/swagger-cli # one time
 swagger-cli validate openapi.yaml 
 ```
 
-To test the YAML
+
+### Test the YAML
 
 ```
 pip3 install schemathesis # one time
 schemathesis run -vvvv --checks not_a_server_error openapi.yaml --base-url http://localhost:9011 -H "Authorization: bf69486b-4733-4470-a592-f1bfce7af580" 
 ```
 
-To generate libraries:
+### Generate libraries
+
+Install either Swagger: https://github.com/swagger-api/swagger-codegen/ or openapi: https://github.com/OpenAPITools/openapi-generator
+
+Java
 
 ```
 cd <dir>
-swagger-codegen generate -i path/to/fusionauth-client-builder/bin/openapi.yaml -l java -o .
+swagger-codegen generate  --group-id io.fusionauth --artifact-id fusionauth-client-library-codegen --artifact-version 1.0.2-SNAPSHOT --api-package io.fusionauth.codegen.api  --invoker-package io.fusionauth.codegen.invoker --model-package io.fusionauth.codegen.model -l java -o . -i ../fusionauth-client-builder/bin/openapi.yaml
 ```
+
+Ruby
+```
+npx @openapitools/openapi-generator-cli generate -i ../fusionauth-client-builder/bin/openapi.yaml -g ruby -o . 
+```
+
+### TODO
+
+There are some flaws. While the specification is valid, the generated client libraries haven't been fully exercised.
+
+In particular:
+
+* polymorphic operations are not well supported by the client library generators. That means that identity provider requests and responses are not functional. I'm not sure if there are workarounds, but it seems like some work is being done. See https://github.com/swagger-api/swagger-codegen/issues/10011 for example.
+* this file is generated from the client-builder JSON files, not from code. This means that there may be gaps when compared to the REST API.
+* there are certain operations, status codes and security mechanisms (JWT auth, cookies for auth) that are not currently supported. 
+* oauth specific operations are not currently supported.
+
+Rollout plan:
+
+* Review with eng team, determine if current state is shippable to alpha users.
+* Ask folks who commened on https://github.com/FusionAuth/fusionauth-issues/issues/614 or otherwise expressed interest in this to kick the tires.
+* Determine what features need to be added to ship.
+* Fix any outstanding issues/add features.
+* Publish as 'tech preview' in docs. Close bugs for other SDKs.
+* Let it burn in for a few months, fix any issues.
+* Start publishing it as part of the release process. Maybe include it in the build? Maybe just on the download page.
+* Go back and provide specs for previous releases so that folks can use apidiff functionality.
+* Investigate bringing things closer to the code/fusionauth-app so that we don't need to maintain the API JSON files.

--- a/README.md
+++ b/README.md
@@ -88,5 +88,3 @@ sb build-all
 ```
 
 For more information on the Savant build tool, checkout [savantbuild.org](http://savantbuild.org/).
-
-

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -13,6 +13,9 @@ options = {}
 options[:sourcedir] = "../src/"
 options[:outfile] = "openapi.yaml"
 
+# openapi component that defines our api key auth
+api_key_auth_name = "ApiKeyAuth"
+
 OptionParser.new do |opts|
   opts.banner = "Usage: build-openapi-yaml.rb [options]"
 
@@ -462,12 +465,12 @@ def build_nested_content_response(hash, ref, description)
   end
 end
 
-def build_security_schemes
+def build_security_schemes(api_key_auth_name)
   security_schemes = {}
-  security_schemes["apikey"] = {}
-  security_schemes["apikey"]["type"] = "apiKey"
-  security_schemes["apikey"]["name"] = "Authorization"
-  security_schemes["apikey"]["in"] = "header"
+  security_schemes[api_key_auth_name] = {}
+  security_schemes[api_key_auth_name]["type"] = "apiKey"
+  security_schemes[api_key_auth_name]["name"] = "Authorization"
+  security_schemes[api_key_auth_name]["in"] = "header"
 
   # TODO we don't have a way in the json to designate these api calls. need to extend the metadata
   #security_schemes["jwt"] = {}
@@ -544,7 +547,7 @@ schemas["ZoneId"]["type"] = "string"
 
 
 components["schemas"] = schemas
-components["securitySchemes"] = build_security_schemes
+components["securitySchemes"] = build_security_schemes(api_key_auth_name)
 
 api_files.each do |fn|
   process_api_file(fn, paths, options)
@@ -563,7 +566,7 @@ info:
 servers:
   - url: http://localhost:9011
 security:
-  - apikey: []
+  - #{api_key_auth_name}: []
 )
 
   # components and paths

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -12,6 +12,7 @@ options = {}
 # default options
 options[:sourcedir] = "../src/"
 options[:outfile] = "openapi.yaml"
+options[:apiversion] = "1.0.0"
 
 # openapi component that defines our api key auth
 api_key_auth_name = "ApiKeyAuth"
@@ -21,6 +22,10 @@ OptionParser.new do |opts|
 
   opts.on("-v", "--verbose", "Run verbosely.") do |v|
     options[:verbose] = v
+  end
+
+  opts.on("-a", "--api-version SEMVER", "The api version for this build.") do |av|
+    options[:apiversion] = av
   end
 
   opts.on("-d", "--source-directory DIR", "Source directory.") do |d|
@@ -643,7 +648,7 @@ File.open(options[:outfile], "w") do |f|
   f.write %Q(
 openapi: "3.0.3"
 info:
-  version: 1.0.0
+  version: #{options[:apiversion]}
   title: FusionAuth API
   license:
     name: Apache2

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -281,11 +281,14 @@ def process_api_file(fn, paths, options)
 
 end
 
-def build_path(uri, json, paths, include_optional_segement_param, options)
+def build_path(uri, json, paths, include_optional_segment_param, options)
 
   method = json["method"]
   desc = json["comments"].join(" ").delete("\n").strip
   operationId = json["methodName"]
+  if include_optional_segment_param
+    operationId += "WithId"
+  end
   jsonparams = json["params"]
 
   if not paths[uri] 
@@ -323,7 +326,7 @@ def build_path(uri, json, paths, include_optional_segement_param, options)
       end
 
       if param_optional(p["comments"])
-        if include_optional_segement_param
+        if include_optional_segment_param
           # we have an optional param but it is in the URI, so we want to add it to the parameters
           params << build_openapi_paramobj(p, "path")
         end

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -191,6 +191,11 @@ def process_domain_file(fn, schemas, options, identity_providers)
             else
               properties[k]["additionalProperties"]['$ref'] = make_ref(mapValueType)
             end
+
+            # no additional properties
+            if properties[k]["additionalProperties"].length == 0
+              properties[k].delete("additionalProperties")
+            end
           else
             if v2.match(/BaseIdentityProvider$/)
                # special handling of this
@@ -541,4 +546,5 @@ puts spec.to_yaml.gsub(/^---/,'')
 # TODO X-Forwarded-For
 # TODO cookies
 # TODO outfile
-# TODO identity provider type (null?
+# TODO error messages swallowed all the time in the java client
+# TODO anyof https://github.com/swagger-api/swagger-codegen/issues/10011 

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -400,12 +400,6 @@ def merge_operations(new_api_object, old_api_object, uri, method)
 
   # make sure if we have a requestBody, we pass that along in the merge. This will blow up if we have two operations that take request bodies but don't have the same request body
   if old_api_object["requestBody"] && !new_api_object["requestBody"]
-    #puts "abbbb" + uri
-    new_api_object["requestBody"] = old_api_object["requestBody"]
-  end
-
-  if new_api_object["requestBody"] && !old_api_object["requestBody"]
-    #puts "acccc" + uri
     new_api_object["requestBody"] = old_api_object["requestBody"]
   end
 

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -257,7 +257,7 @@ def process_api_file(fn, paths, options)
   method = json["method"]
   uri = json["uri"]
   if paths[uri] && paths[uri][method] && options[:verbose] 
-    puts "duplicate " + uri + " " + method
+    puts "duplicate " + uri + " " + method + " fn: "+fn
   end
   # end debugging
 
@@ -440,9 +440,11 @@ def build_security_schemes
   security_schemes["apikey"]["type"] = "apiKey"
   security_schemes["apikey"]["name"] = "Authorization"
   security_schemes["apikey"]["in"] = "header"
-  security_schemes["jwt"] = {}
-  security_schemes["jwt"]["type"] = "http"
-  security_schemes["jwt"]["scheme"] = "Bearer"
+
+  # TODO we don't have a way in the json to designate these api calls. need to extend the metadata
+  #security_schemes["jwt"] = {}
+  #security_schemes["jwt"]["type"] = "http"
+  #security_schemes["jwt"]["scheme"] = "Bearer"
 
   return security_schemes
 end
@@ -542,9 +544,10 @@ puts spec.to_yaml.gsub(/^---/,'')
 # TODO custom deserializers? IdentityProviderRequestDeserializer or is that handled by openapi?
 
 # not defined anywhere, we don't support this yet
-# TODO status codes
+# TODO more status codes
+
 # TODO X-Forwarded-For
 # TODO cookies
 # TODO outfile
-# TODO error messages swallowed all the time in the java client
 # TODO anyof https://github.com/swagger-api/swagger-codegen/issues/10011 
+# TODO content -type is sent on GETs https://github.com/swagger-api/swagger-codegen/issues/8310

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -42,7 +42,7 @@ OptionParser.new do |opts|
 end.parse!
 
 def is_primitive(type)
-  return type == "boolean" || type == "String" || type == "UUID" || type == "Object" || type == "int" || "type" == "integer" ||type == "Set" || type == "URI" || type == "SortedSet" || type == "long" || type == "double" || type == "char" || type == "Array"
+  ["boolean", "String", "UUID", "Object", "int", "integer", "Set", "URI", "SortedSet", "long", "double", "char", "Array"].include? type
 end
 
 def convert_primitive(type)

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -20,8 +20,8 @@ OptionParser.new do |opts|
     options[:verbose] = v
   end
 
-  opts.on("-d", "--source-directory", "Source directory.") do |v|
-    options[:sourcedir] = v
+  opts.on("-d", "--source-directory DIR", "Source directory.") do |d|
+    options[:sourcedir] = d
   end
 
   opts.on("-f", "--file FILE", "Run for one file.") do |file|

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -529,7 +529,8 @@ end
 schemas["ZonedDateTime"] = {}
 schemas["ZonedDateTime"]["description"] = "A date-time with a time-zone in the ISO-8601 calendar system, such as 2007-12-03T10:15:30+01:00 Europe/Paris."
 schemas["ZonedDateTime"]["example"] = "2007-12-03"
-schemas["ZonedDateTime"]["type"] = "string"
+schemas["ZonedDateTime"]["type"] = "integer"
+schemas["ZonedDateTime"]["format"] = "int64"
 schemas["Locale"] = {}
 schemas["Locale"]["description"] = "A Locale object represents a specific geographical, political, or cultural region."
 schemas["Locale"]["example"] = "en_US"

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -353,8 +353,6 @@ def build_path(uri, json, paths, include_optional_segment_param, options)
   end
   
 
-  # TODO should we handle type form, notUsed? that is used for oauth token exchange
-  
   params = []
   openapiobj["parameters"] = params
 
@@ -405,7 +403,7 @@ end
 
 def add_header_params(params, json)
 
-   # TODO this info should be shoved into the JSON at the API call. This is currently absent and only available in the docs or code
+   # TODO this info should be shoved into the api definition JSON in client builder. This is currently absent and only available in the docs or code or here
    apis_requiring_tenant_header = ["tenant","user-action","entity","user/family","user","two-factor","user/comment","application","email/template","user/registration","group","consent"]
 
    apis_with_optional_tenant_header = ["login", "passwordless", "identity-provider/login","jwt"]
@@ -481,7 +479,6 @@ end
 
 ######### processing starts
 
-
 domain_files = []
 api_files = []
 schemas = {}
@@ -553,7 +550,10 @@ api_files.each do |fn|
   process_api_file(fn, paths, options)
 end
 
-puts %Q(
+File.open(options[:outfile], "w") do |f|
+
+  # header
+  f.write %Q(
 openapi: "3.0.3"
 info:
   version: 1.0.0
@@ -566,18 +566,19 @@ security:
   - apikey: []
 )
 
-# https://stackoverflow.com/questions/21251309/how-to-remove-on-top-of-a-yaml-file
-puts spec.to_yaml.gsub(/^---/,'')
+  # components and paths
+  # https://stackoverflow.com/questions/21251309/how-to-remove-on-top-of-a-yaml-file
+  f.write spec.to_yaml.gsub(/^---/,'')
+end
 
-# TODO handle {} in component schema
-# TODO handle $ in names only needed where they collide, use modify_type
+# TODO handle {} in component schema ? 
 # TODO custom deserializers? IdentityProviderRequestDeserializer or is that handled by openapi?
 
 # not defined anywhere, we don't support this yet
 # TODO more status codes
 
-# TODO X-Forwarded-For
 # TODO cookies
-# TODO outfile
 # TODO anyof https://github.com/swagger-api/swagger-codegen/issues/10011 
 # TODO content -type is sent on GETs https://github.com/swagger-api/swagger-codegen/issues/8310
+# TODO should we handle type form, notUsed? that is used for oauth token exchange
+  

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -1,0 +1,183 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+require 'yaml'
+
+# option handling
+options = {}
+
+# default options
+options[:sourcedir] = "../src/"
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: check-apis-against-client-json.rb [options]"
+
+  opts.on("-v", "--verbose", "Run verbosely.") do |v|
+    options[:verbose] = v
+  end
+
+  opts.on("-d", "--source-directory", "Source directory.") do |v|
+    options[:sourcedir] = v
+  end
+
+  opts.on("-f", "--file FILE", "Run for one file.") do |file|
+    options[:file] = file
+  end
+
+  opts.on("-o", "--out FILE", "Ouput file.") do |outfile|
+    options[:outfile] = outfile
+  end
+
+  opts.on("-h", "--help", "Prints this help.") do
+    puts opts
+    exit
+  end
+end.parse!
+
+def is_primitive(type)
+  return type == "boolean" || type == "String" || type == "UUID" || type == "Object"
+end
+
+def convert_primitive(type)
+  if type == "boolean"
+    return {"type" => "boolean"}
+  end
+  if type == "Object"
+    return {"type" => "object"}
+  end
+
+  if type == "UUID"
+    return {"type" => "string", "format" => "uuid"}
+  end
+
+  if type == "String"
+    return {"type" => "string"}
+  end
+
+  if type == "integer"
+    return {"type" => "integer"}
+  end
+end
+
+def make_ref(type)
+  return "'#/components/schemas/"+type+"'"
+end
+
+def process_file(fn, schemas, options)
+  if options[:verbose] 
+    puts "processing "+fn
+  end
+
+  f = File.open(fn)
+  fs = f.read
+  json = JSON.parse(fs)
+  f.close
+
+  openapiobj = {}
+  if json["description"]
+    openapiobj["description"] = json["description"].gsub('/','').gsub(/@au.*/,'').gsub('*','').gsub(/\n/,'').gsub("\n",'').delete("\n").strip
+  end
+  openapiobj["type"] = "object"
+
+
+  # TODO handle undefined types like UUID
+  # TODO What about ENUMS in an existing data model with fields?
+  if json["enum"] 
+    openapiobj["type"] = "string"
+    openapiobj["enum"] = json["enum"]
+  end
+
+
+  if json["fields"]
+    properties = {}
+    openapiobj["properties"] = properties
+    json["fields"] && json["fields"].each do |k,v|
+      properties[k] = {}
+      v.each do |k2,v2|
+        if k2 == "type" 
+          if is_primitive(v2)
+            properties[k] = convert_primitive(v2)
+          elsif v2 == "List"
+            properties[k][k2] = "array"
+            properties[k]["items"] = {}
+            listElementType = json["fields"][k]["typeArguments"][0]["type"]
+            if is_primitive(listElementType)
+              properties[k]["items"] = convert_primitive(listElementType)
+            else
+              properties[k]["items"]['$ref'] = make_ref(listElementType)
+            end
+          elsif v2 == "Map"
+            properties[k][k2] = "object"
+            properties[k]["additionalProperties"] = {}
+            mapElementType = json["fields"][k]["typeArguments"][1]["type"]
+            if is_primitive(mapElementType)
+              properties[k]["additionalProperties"] = convert_primitive(mapElementType)
+            else
+              properties[k]["additionalProperties"]['$ref'] = make_ref(mapElementType)
+            end
+          else
+            # omit type, put in ref
+            properties[k]['$ref'] = make_ref(v2)
+          end
+        end
+      end
+    end
+  end
+
+  schemas[json["type"]] = openapiobj 
+
+end
+
+files = []
+schemas = {}
+components = {}
+spec = {}
+spec["components"] = components
+
+if options[:file]
+  files = Dir.glob(options[:sourcedir]+"/main/domain/*"+options[:file]+"*")
+else
+  files = Dir.glob(options[:sourcedir]+"/main/domain/*")
+end
+
+if options[:verbose] 
+  puts "Checking files: "
+  puts files
+end
+
+
+files.each do |fn|
+  process_file(fn, schemas, options)
+end
+
+components["schemas"] = schemas
+
+puts %Q(
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      responses:
+        '200':
+          description: A paged array of pets
+          content:
+            application/json:   
+              schema:
+                $ref: "#/components/schemas/UserAction"
+)
+
+# https://stackoverflow.com/questions/21251309/how-to-remove-on-top-of-a-yaml-file
+
+puts spec.to_yaml.gsub(/^---/,'')
+

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -429,8 +429,8 @@ def add_header_params(params, json)
    header_param = {}
    header_param["in"] = "header"
    header_param["name"] = "X-FusionAuth-TenantId"
-   header_param["description"] = "The unique Id of the tenant used to scope this API request."
-   header_param["required"] = required
+   header_param["description"] = "The unique Id of the tenant used to scope this API request. Only required when there is more than one tenant and the API key is not tenant-scoped."
+   header_param["required"] = false
    header_param["schema"] = {}
    header_param["schema"]["type"] = "string"
    header_param["schema"]["format"] = "UUID"

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -112,7 +112,6 @@ def process_domain_file(fn, schemas, options)
 
   # TODO What about ENUMS in an existing data model with fields?
   # TODO authentication schemes
-  # TODO handle extends, jam all fields on super classes onto object
   if json["enum"] 
     openapiobj["type"] = "string"
     openapiobj["enum"] = json["enum"]
@@ -276,7 +275,6 @@ def build_path(uri, json, paths, include_optional_segement_param, options)
   openapiobj["operationId"] = operationId
 
   # TODO should we handle type form, notUsed? that is used for oauth token exchange
-  # TODO need to handle body params
   
   if jsonparams
     params = []
@@ -302,6 +300,14 @@ def build_path(uri, json, paths, include_optional_segement_param, options)
       else
         params << build_openapi_paramobj(p, "path")
       end
+    end
+
+    if bodyparams && bodyparams.length > 0
+      openapiobj["requestBody"] = {}
+      openapiobj["requestBody"]["content"] = {}
+      openapiobj["requestBody"]["content"]["application/json"] = {}
+      openapiobj["requestBody"]["content"]["application/json"]["schema"] = {}
+      openapiobj["requestBody"]["content"]["application/json"]["schema"]["$ref"] = make_ref(bodyparams[0]["javaType"])
     end
   end
 

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -397,6 +397,18 @@ def merge_operations(new_api_object, old_api_object, uri, method)
 
   #remove dups
   new_api_object["parameters"] = new_api_object["parameters"].uniq { |p| p["name"] }
+
+  # make sure if we have a requestBody, we pass that along in the merge. This will blow up if we have two operations that take request bodies but don't have the same request body
+  if old_api_object["requestBody"] && !new_api_object["requestBody"]
+    #puts "abbbb" + uri
+    new_api_object["requestBody"] = old_api_object["requestBody"]
+  end
+
+  if new_api_object["requestBody"] && !old_api_object["requestBody"]
+    #puts "acccc" + uri
+    new_api_object["requestBody"] = old_api_object["requestBody"]
+  end
+
   return new_api_object
 end
 

--- a/build.savant
+++ b/build.savant
@@ -236,6 +236,10 @@ target(name: "build-dart", description: "Build the Dart Client Library") {
   formatClientLibrary("fusionauth-dart-client")
 }
 
+target(name: "build-openapi", description: "Build the OpenAPI file") {
+  cleanExecute(["ruby", "bin/build-openapi-yaml.rb", "--source-directory", "./src", "--out", "../fusionauth-openapi/openapi.yaml"], false)
+}
+
 target(name: "build-all", description: "Builds all client libraries", dependsOn: ["build-java",
                                                                                   "build-php",
 //                                                                                  "build-angular",
@@ -244,10 +248,12 @@ target(name: "build-all", description: "Builds all client libraries", dependsOn:
                                                                                   "build-node",
                                                                                   "build-typescript",
                                                                                   "build-javascript",
+                                                                                  "build-openapi",
                                                                                   "build-python",
                                                                                   "build-ruby",
                                                                                   "build-dart"]) {
 }
+
 
 // Still testing this to see if it will work with stdout and prompts, etc which are required for dart, and python. Perhaps we can configure all of this to
 // skip all requests for input or confirmations.
@@ -256,11 +262,11 @@ target(name: "build-all", description: "Builds all client libraries", dependsOn:
 //        to call this target from CI during a release.
 //
 target(name: "publish-all", description: "Publish all client libraries") {
-  ["dart", "java", "netcore", "node", "php", "python", "ruby", "typescript"].each { client ->
+  ["dart-client", "java-client", "netcore-client", "node-client", "php-client", "python-client", "ruby-client", "typescript-client", "openapi"].each { client ->
     ProcessBuilder pb = new ProcessBuilder(
         "sb", "publish")
         .inheritIO()
-        .directory(new File("../fusionauth-${client}-client"))
+        .directory(new File("../fusionauth-${client}"))
 
     def process = pb.start()
     process.consumeProcessOutput(System.out, System.err)
@@ -268,3 +274,4 @@ target(name: "publish-all", description: "Publish all client libraries") {
     return process.exitValue() == 0
   }
 }
+

--- a/build.savant
+++ b/build.savant
@@ -237,7 +237,7 @@ target(name: "build-dart", description: "Build the Dart Client Library") {
 }
 
 target(name: "build-openapi", description: "Build the OpenAPI file") {
-  cleanExecute(["ruby", "bin/build-openapi-yaml.rb", "--source-directory", "./src", "--out", "../fusionauth-openapi/openapi.yaml"], false)
+  cleanExecute(["ruby", "bin/build-openapi-yaml.rb", "--source-directory", "./src", "--out", "../fusionauth-openapi/openapi.yaml"])
 }
 
 target(name: "build-all", description: "Builds all client libraries", dependsOn: ["build-java",
@@ -275,3 +275,11 @@ target(name: "publish-all", description: "Publish all client libraries") {
   }
 }
 
+boolean cleanExecute(List<String> args) {
+  ProcessBuilder pb = new ProcessBuilder(args).inheritIO().directory(new File('.'))
+
+  def process = pb.start()
+  process.consumeProcessOutput(System.out, System.err)
+  process.waitFor()
+  return process.exitValue() == 0
+}

--- a/build.savant
+++ b/build.savant
@@ -237,7 +237,8 @@ target(name: "build-dart", description: "Build the Dart Client Library") {
 }
 
 target(name: "build-openapi", description: "Build the OpenAPI file") {
-  cleanExecute(["ruby", "bin/build-openapi-yaml.rb", "--source-directory", "./src", "--out", "../fusionauth-openapi/openapi.yaml"])
+  projVersion = project.version.toString()
+  cleanExecute(["ruby", "bin/build-openapi-yaml.rb", "--source-directory", "./src", "--out", "../fusionauth-openapi/openapi.yaml", "--api-version", projVersion])
 }
 
 target(name: "build-all", description: "Builds all client libraries", dependsOn: ["build-java",


### PR DESCRIPTION
This is a first pass at generating an openAPI yaml file from the API and domain JSON files.

This deploys files to the https://github.com/FusionAuth/fusionauth-openapi repository, where it can be versioned and released like any other client library package (not quite sure how the release plugin works, so I just copy pastaed it).

There are some flaws in the implementation. While the specification is valid, the generated client libraries haven't been fully exercised.

In particular:

* polymorphic operations are not well supported by the client library generators. That means that identity provider requests and responses are not functional. I'm not sure if there are workarounds, but it seems like some work is being done. See https://github.com/swagger-api/swagger-codegen/issues/10011 for example.
* this file is generated from the fusionauth-client-builder JSON files, not from code. This means that there may be gaps when compared to the REST API.
* there's no information about what parameters are required or not, because that is not part of the API JSON files.
* there are certain operations, status codes and security mechanisms (JWT auth, cookies for auth) that are not currently supported, again, because they are not included in the API JSON files.
* oauth specific operations are not currently supported

Rollout plan:

* Review with eng team, determine if current state is shippable to alpha users.
* Ask folks who commented on https://github.com/FusionAuth/fusionauth-issues/issues/614 or otherwise expressed interest in this to kick the tires.
* Determine what features need to be added to ship.
* Fix any outstanding issues/add features.
* Publish as 'tech preview' in docs. Close bugs for other SDKs.
* Let it burn in for a few months, fix any issues.
* Start publishing it as part of the release process. Maybe include it in the build? Maybe just on the download page.
* Go back and provide specs for previous releases so that folks can use apidiff functionality.
* Investigate bringing things closer to the code/fusionauth-app so that we don't need to maintain the API JSON files.