### PR TITLE
Verifying email address by userId

### DIFF
--- a/src/main/api/verifyEmailAddress.json
+++ b/src/main/api/verifyEmailAddress.json
@@ -6,7 +6,9 @@
     "The request body will contain the verificationId. You may also be required to send a one-time use code based upon your configuration. When ",
     "the tenant is configured to gate a user until their email address is verified, this procedures requires two values instead of one. ",
     "The verificationId is a high entropy value and the one-time use code is a low entropy value that is easily entered in a user interactive form. The ",
-    "two values together are able to confirm a user's email address and mark the user's email address as verified."
+    "two values together are able to confirm a user's email address and mark the user's email address as verified.",
+    "",
+    "Requests made with an API key can instead provide a userId in the request body to override email verification for the user."
   ],
   "method": "post",
   "methodName": "verifyEmailAddress",
@@ -17,7 +19,9 @@
     {
       "name": "request",
       "comments": [
-        "The request that contains the verificationId and optional one-time use code paired with the verificationId."
+        "The request that contains the verificationId and optional one-time use code paired with the verificationId.",
+        "",
+        "API key-authenticated requests can instead provide a userId to override the email verification status for the user."
       ],
       "type": "body",
       "javaType": "VerifyEmailRequest"

--- a/src/main/api/verifyEmailAddress.json
+++ b/src/main/api/verifyEmailAddress.json
@@ -6,9 +6,7 @@
     "The request body will contain the verificationId. You may also be required to send a one-time use code based upon your configuration. When ",
     "the tenant is configured to gate a user until their email address is verified, this procedures requires two values instead of one. ",
     "The verificationId is a high entropy value and the one-time use code is a low entropy value that is easily entered in a user interactive form. The ",
-    "two values together are able to confirm a user's email address and mark the user's email address as verified.",
-    "",
-    "Requests made with an API key can instead provide a userId in the request body to override email verification for the user."
+    "two values together are able to confirm a user's email address and mark the user's email address as verified."
   ],
   "method": "post",
   "methodName": "verifyEmailAddress",
@@ -19,9 +17,7 @@
     {
       "name": "request",
       "comments": [
-        "The request that contains the verificationId and optional one-time use code paired with the verificationId.",
-        "",
-        "API key-authenticated requests can instead provide a userId to override the email verification status for the user."
+        "The request that contains the verificationId and optional one-time use code paired with the verificationId."
       ],
       "type": "body",
       "javaType": "VerifyEmailRequest"

--- a/src/main/api/verifyEmailAddressByUserId.json
+++ b/src/main/api/verifyEmailAddressByUserId.json
@@ -3,7 +3,7 @@
   "comments": [
     "Administratively verify a user's email address. Use this method to bypass email verification for the user.",
     "",
-    "The request body will contain the userId to be verified. This manual verification method requires an API key."
+    "The request body will contain the userId to be verified. An API key is required when sending the userId in the request body."
   ],
   "method": "post",
   "methodName": "verifyEmailAddressByUserId",

--- a/src/main/api/verifyEmailAddressByUserId.json
+++ b/src/main/api/verifyEmailAddressByUserId.json
@@ -1,7 +1,7 @@
 {
   "uri": "/api/user/verify-email",
   "comments": [
-    "Manually confirms a user's email address. ",
+    "Administratively verify a user's email address. Use this method to bypass email verification for the user.",
     "",
     "The request body will contain the userId to be verified. This manual verification method requires an API key."
   ],

--- a/src/main/api/verifyEmailAddressByUserId.json
+++ b/src/main/api/verifyEmailAddressByUserId.json
@@ -1,0 +1,22 @@
+{
+  "uri": "/api/user/verify-email",
+  "comments": [
+    "Manually confirms a user's email address. ",
+    "",
+    "The request body will contain the userId to be verified. This manual verification method requires an API key."
+  ],
+  "method": "post",
+  "methodName": "verifyEmailAddressByUserId",
+  "successResponse": "Void",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "request",
+      "comments": [
+        "The request that contains the userId to verify."
+      ],
+      "type": "body",
+      "javaType": "VerifyEmailRequest"
+    }
+  ]
+}

--- a/src/main/domain/io.fusionauth.domain.api.user.VerifyEmailRequest.json
+++ b/src/main/domain/io.fusionauth.domain.api.user.VerifyEmailRequest.json
@@ -11,6 +11,9 @@
     },
     "verificationId" : {
       "type" : "String"
+    },
+    "userId" :  {
+      "type": "UUID"
     }
   }
 }

--- a/src/main/domain/io.fusionauth.domain.api.user.VerifyEmailRequest.json
+++ b/src/main/domain/io.fusionauth.domain.api.user.VerifyEmailRequest.json
@@ -12,8 +12,8 @@
     "verificationId" : {
       "type" : "String"
     },
-    "userId" :  {
-      "type": "UUID"
+    "userId" : {
+      "type" : "UUID"
     }
   }
 }


### PR DESCRIPTION
Update and document API changes to verify email address by `userId` rather than the generated `verficiationId`.

**Issue**
- https://github.com/FusionAuth/fusionauth-issues/issues/1319

**Linked PRs**
- https://github.com/FusionAuth/fusionauth-app/pull/119
- https://github.com/FusionAuth/fusionauth-api/pull/53
- https://github.com/FusionAuth/fusionauth-java-client/pull/30