### PR TITLE
Fixed url segment name

### DIFF
--- a/src/main/api/retrieveRefreshTokenById.json
+++ b/src/main/api/retrieveRefreshTokenById.json
@@ -1,7 +1,7 @@
 {
   "uri": "/api/jwt/refresh",
   "comments": [
-    "Retrieves a single refresh token by unique Id. This is not the same thing as the string value of the refresh token, if you have that, you already have what you need.."
+    "Retrieves a single refresh token by unique Id. This is not the same thing as the string value of the refresh token. If you have that, you already have what you need."
   ],
   "method": "get",
   "methodName": "retrieveRefreshTokenById",
@@ -9,9 +9,9 @@
   "errorResponse": "Errors",
   "params": [
     {
-      "name": "userId",
+      "name": "tokenId",
       "comments": [
-        "The Id of the user."
+        "The Id of the token."
       ],
       "type": "urlSegment",
       "javaType": "UUID"


### PR DESCRIPTION
The JSON had an incorrect segment name, looked like a copy pasta error.

This is part of resolving https://github.com/FusionAuth/fusionauth-issues/issues/1724