### PR TITLE
Group search/pagination updates

### DIFF
--- a/src/main/api/searchTenants.json
+++ b/src/main/api/searchTenants.json
@@ -1,0 +1,20 @@
+{
+  "uri": "/api/tenant/search",
+  "comments": [
+    "Searches tenants with the specified criteria and pagination."
+  ],
+  "method": "post",
+  "methodName": "searchTenants",
+  "successResponse": "TenantSearchResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "request",
+      "comments": [
+        "The search criteria and pagination information."
+      ],
+      "type": "body",
+      "javaType": "TenantSearchRequest"
+    }
+  ]
+}

--- a/src/main/client/java.client.ftl
+++ b/src/main/client/java.client.ftl
@@ -1,6 +1,6 @@
 [#import "_macros.ftl" as global/]
 /*
- * Copyright (c) 2018-2022, FusionAuth, All Rights Reserved
+ * Copyright (c) 2018-2023, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,8 @@ import io.fusionauth.domain.api.SystemConfigurationResponse;
 import io.fusionauth.domain.api.TenantDeleteRequest;
 import io.fusionauth.domain.api.TenantRequest;
 import io.fusionauth.domain.api.TenantResponse;
+import io.fusionauth.domain.api.TenantSearchRequest;
+import io.fusionauth.domain.api.TenantSearchResponse;
 import io.fusionauth.domain.api.ThemeRequest;
 import io.fusionauth.domain.api.ThemeResponse;
 import io.fusionauth.domain.api.TwoFactorDisableRequest;

--- a/src/main/domain/io.fusionauth.domain.api.TenantSearchRequest.json
+++ b/src/main/domain/io.fusionauth.domain.api.TenantSearchRequest.json
@@ -1,0 +1,16 @@
+{
+  "packageName" : "io.fusionauth.domain.api",
+  "type" : "TenantSearchRequest",
+  "description" : "/**\n * Search request for Tenants\n *\n * @author Mark Manes\n */\n",
+  "implements" : [ {
+    "type" : "Buildable",
+    "typeArguments" : [ {
+      "type" : "TenantSearchRequest"
+    } ]
+  } ],
+  "fields" : {
+    "search" : {
+      "type" : "TenantSearchCriteria"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.api.TenantSearchResponse.json
+++ b/src/main/domain/io.fusionauth.domain.api.TenantSearchResponse.json
@@ -1,0 +1,16 @@
+{
+  "packageName" : "io.fusionauth.domain.api",
+  "type" : "TenantSearchResponse",
+  "description" : "/**\n * Tenant search response\n *\n * @author Mark Manes\n */\n",
+  "fields" : {
+    "tenants" : {
+      "type" : "List",
+      "typeArguments" : [ {
+        "type" : "Tenant"
+      } ]
+    },
+    "total" : {
+      "type" : "long"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.search.BaseSearchCriteria.json
+++ b/src/main/domain/io.fusionauth.domain.search.BaseSearchCriteria.json
@@ -3,9 +3,6 @@
   "type" : "BaseSearchCriteria",
   "description" : "/**\n * @author Brian Pontarelli\n */\n",
   "fields" : {
-    "maxHitCount" : {
-      "type" : "int"
-    },
     "numberOfResults" : {
       "type" : "int"
     },

--- a/src/main/domain/io.fusionauth.domain.search.GroupSearchCriteria.json
+++ b/src/main/domain/io.fusionauth.domain.search.GroupSearchCriteria.json
@@ -11,6 +11,9 @@
     },
     "tenantId" : {
       "type" : "UUID"
+    },
+    "query" : {
+      "type" : "String"
     }
   }
 }

--- a/src/main/domain/io.fusionauth.domain.search.GroupSearchCriteria.json
+++ b/src/main/domain/io.fusionauth.domain.search.GroupSearchCriteria.json
@@ -11,9 +11,6 @@
     },
     "tenantId" : {
       "type" : "UUID"
-    },
-    "query" : {
-      "type" : "String"
     }
   }
 }

--- a/src/main/domain/io.fusionauth.domain.search.TenantSearchCriteria.json
+++ b/src/main/domain/io.fusionauth.domain.search.TenantSearchCriteria.json
@@ -1,0 +1,19 @@
+{
+  "packageName" : "io.fusionauth.domain.search",
+  "type" : "TenantSearchCriteria",
+  "description" : "/**\n * Search criteria for Tenants\n *\n * @author Mark Manes\n */\n",
+  "extends" : [ {
+    "type" : "BaseSearchCriteria"
+  } ],
+  "implements" : [ {
+    "type" : "Buildable",
+    "typeArguments" : [ {
+      "type" : "TenantSearchCriteria"
+    } ]
+  } ],
+  "fields" : {
+    "query" : {
+      "type" : "String"
+    }
+  }
+}


### PR DESCRIPTION
_Draft until https://github.com/FusionAuth/fusionauth-client-builder/pull/52 is merged_
### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2057

### Summary
Update `/api/group/search` endpoint. Regenerate domain objects.

### Related
- https://github.com/FusionAuth/fusionauth-app/pull/193

### Notes
This includes the removal of the `maxHitCount` parameter which was made for a different change, but not applied to the client yet.