### PR TITLE
Themes search & pagination

### DIFF
--- a/src/main/api/searchThemes.json
+++ b/src/main/api/searchThemes.json
@@ -1,0 +1,20 @@
+{
+  "uri": "/api/theme/search",
+  "comments": [
+    "Searches themes with the specified criteria and pagination."
+  ],
+  "method": "post",
+  "methodName": "searchThemes",
+  "successResponse": "ThemeSearchResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "request",
+      "comments": [
+        "The search criteria and pagination information."
+      ],
+      "type": "body",
+      "javaType": "ThemeSearchRequest"
+    }
+  ]
+}

--- a/src/main/client/java.client.ftl
+++ b/src/main/client/java.client.ftl
@@ -125,6 +125,8 @@ import io.fusionauth.domain.api.TenantSearchRequest;
 import io.fusionauth.domain.api.TenantSearchResponse;
 import io.fusionauth.domain.api.ThemeRequest;
 import io.fusionauth.domain.api.ThemeResponse;
+import io.fusionauth.domain.api.ThemeSearchRequest;
+import io.fusionauth.domain.api.ThemeSearchResponse;
 import io.fusionauth.domain.api.TwoFactorDisableRequest;
 import io.fusionauth.domain.api.TwoFactorRecoveryCodeResponse;
 import io.fusionauth.domain.api.TwoFactorRequest;

--- a/src/main/domain/io.fusionauth.domain.api.ThemeSearchRequest.json
+++ b/src/main/domain/io.fusionauth.domain.api.ThemeSearchRequest.json
@@ -1,0 +1,16 @@
+{
+  "packageName" : "io.fusionauth.domain.api",
+  "type" : "ThemeSearchRequest",
+  "description" : "/**\n * Search request for Themes.\n *\n * @author Mark Manes\n */\n",
+  "implements" : [ {
+    "type" : "Buildable",
+    "typeArguments" : [ {
+      "type" : "ThemeSearchRequest"
+    } ]
+  } ],
+  "fields" : {
+    "search" : {
+      "type" : "ThemeSearchCriteria"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.api.ThemeSearchResponse.json
+++ b/src/main/domain/io.fusionauth.domain.api.ThemeSearchResponse.json
@@ -1,0 +1,16 @@
+{
+  "packageName" : "io.fusionauth.domain.api",
+  "type" : "ThemeSearchResponse",
+  "description" : "/**\n * Search response for Themes\n *\n * @author Mark Manes\n */\n",
+  "fields" : {
+    "themes" : {
+      "type" : "List",
+      "typeArguments" : [ {
+        "type" : "Theme"
+      } ]
+    },
+    "total" : {
+      "type" : "long"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.search.ThemeSearchCriteria.json
+++ b/src/main/domain/io.fusionauth.domain.search.ThemeSearchCriteria.json
@@ -1,0 +1,13 @@
+{
+  "packageName" : "io.fusionauth.domain.search",
+  "type" : "ThemeSearchCriteria",
+  "description" : "/**\n * Search criteria for themes\n *\n * @author Mark Manes\n */\n",
+  "extends" : [ {
+    "type" : "BaseSearchCriteria"
+  } ],
+  "fields" : {
+    "name" : {
+      "type" : "String"
+    }
+  }
+}


### PR DESCRIPTION
### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2058

### Summary
Add `/api/theme/search` endpoint. Regenerate domain objects.

### Related
- https://github.com/FusionAuth/fusionauth-app/pull/199