### PR TITLE
Ability to provide RestClientBuilder to FusionAuthClient

### DIFF
--- a/src/main/client/netcore.client.ftl
+++ b/src/main/client/netcore.client.ftl
@@ -41,12 +41,12 @@ namespace io.fusionauth {
 
     public readonly IRESTClientBuilder clientBuilder;
 
-    public FusionAuthClient(string apiKey, string host, string tenantId = null) {
+    public FusionAuthClient(string apiKey, string host, string tenantId = null, IRESTClientBuilder clientBuilder = null) {
       this.apiKey = apiKey;
       this.host = host;
       this.tenantId = tenantId;
 
-      clientBuilder = new DefaultRESTClientBuilder();
+      this.clientBuilder = clientBuilder ?? new DefaultRESTClientBuilder();
     }
 
     /**
@@ -55,7 +55,7 @@ namespace io.fusionauth {
      */
     // ReSharper disable once ParameterHidesMember
     public FusionAuthClient withTenantId(string tenantId) {
-      return tenantId == null ? this : new FusionAuthClient(apiKey, host, tenantId);
+      return tenantId == null ? this : new FusionAuthClient(apiKey, host, tenantId, clientBuilder);
     }
 
     /**
@@ -64,7 +64,16 @@ namespace io.fusionauth {
      */
     // ReSharper disable once ParameterHidesMember
     public FusionAuthClient withTenantId(Guid? tenantId) {
-      return tenantId == null ? this : new FusionAuthClient(apiKey, host, tenantId.ToString());
+      return tenantId == null ? this : new FusionAuthClient(apiKey, host, tenantId.ToString(), clientBuilder);
+    }
+
+    /**
+     * Return a new instance of FusionAuthClient using the provided client builder.
+     * @param clientBuilder the REST client builder to use for this client.
+     */
+    // ReSharper disable once ParameterHidesMember
+    public FusionAuthClient withClientBuilder(IRESTClientBuilder clientBuilder) {
+      return clientBuilder == null ? this : new FusionAuthClient(apiKey, host, tenantId, clientBuilder);
     }
 
     public IRESTClient buildClient() {


### PR DESCRIPTION
To address https://github.com/FusionAuth/fusionauth-netcore-client/issues/63.

Changes:

- Add an optional `clientBuilder` parameter to the constructor of `FusionAuthClient`
- Propagate `clientBuilder` in `with*` methods of `FusionAuthClient` so that it isn't getting reset.
- Add `withClientBuilder` to follow the `with*` pattern in `FusionAuthClient`