### PR TITLE
Ignore AuthenticationKeySearchCriteria Domain Object

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -96,6 +96,7 @@ target(name: "generateDomain", description: "Generates all of the json files for
       "io.fusionauth.domain.Buildable.json",
       "io.fusionauth.domain.Integration.json",
       "io.fusionauth.domain.internal.annotation.InternalUse.json",
+      "io.fusionauth.domain.search.AuthenticationKeySearchCriteria.json",
       "io.fusionauth.domain.util.DefaultTools.json",
       "io.fusionauth.domain.util.Normalizer.json",
       "io.fusionauth.domain.util.SQLTools.json",


### PR DESCRIPTION
Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2060

Summary
The `AuthenticationKeySearchCriteria` object is an internal domain object. It is not usable by the APIs or client libraries, so it should be ignored when generating the domain for FusionAuth clients.

Related
- https://github.com/FusionAuth/fusionauth-app/pull/207
- https://github.com/inversoft/inversoft-api-authentication/pull/2