### PR TITLE
add preferredLanguages to ApplicationRegistrationConfiguration

### DIFF
--- a/src/main/domain/io.fusionauth.domain.Application$RegistrationConfiguration.json
+++ b/src/main/domain/io.fusionauth.domain.Application$RegistrationConfiguration.json
@@ -38,6 +38,9 @@
     "mobilePhone" : {
       "type" : "Requirable"
     },
+    "preferredLanguages" : {
+      "type" : "Requirable"
+    },
     "type" : {
       "type" : "RegistrationType"
     }


### PR DESCRIPTION
Regenerate domain with new `preferredLanguages` field

### Related (internal)
- https://github.com/FusionAuth/fusionauth-app/pull/215