### PR TITLE
Regenerate domain for Google IdP One Tap

### DIFF
--- a/src/main/domain/io.fusionauth.domain.provider.BooleanApplicationConfiguration.json
+++ b/src/main/domain/io.fusionauth.domain.provider.BooleanApplicationConfiguration.json
@@ -1,0 +1,5 @@
+{
+  "packageName" : "io.fusionauth.domain.provider",
+  "type" : "BooleanApplicationConfiguration",
+  "enum" : [ "Disabled", "Enabled" ]
+}

--- a/src/main/domain/io.fusionauth.domain.provider.GoogleApplicationConfiguration.json
+++ b/src/main/domain/io.fusionauth.domain.provider.GoogleApplicationConfiguration.json
@@ -21,6 +21,9 @@
     "client_secret" : {
       "type" : "String"
     },
+    "enableOneTap" : {
+      "type" : "BooleanApplicationConfiguration"
+    },
     "loginMethod" : {
       "type" : "IdentityProviderLoginMethod"
     },

--- a/src/main/domain/io.fusionauth.domain.provider.GoogleIdentityProvider.json
+++ b/src/main/domain/io.fusionauth.domain.provider.GoogleIdentityProvider.json
@@ -26,6 +26,9 @@
     "client_secret" : {
       "type" : "String"
     },
+    "enableOneTap" : {
+      "type" : "boolean"
+    },
     "loginMethod" : {
       "type" : "IdentityProviderLoginMethod"
     },


### PR DESCRIPTION
Regenerate domain objects for the new Google Identity Provider configuration options for One Tap sign in.

### Related (internal)
- https://github.com/FusionAuth/fusionauth-app/pull/219