### PR TITLE
Filter out mask annotations and add a customer serializer to the client

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -180,6 +180,7 @@ target(name: "build-java", description: "Build the Java Client Library") {
     filter(token: ".*@MaskStringEntry\\.List\\(\\{(\\n|.)*\\}\\)\\n", value: "")
     filter(token: ".*@MaskStringEntry\\(.*\n", value: "")
     filter(token: ".*@MaskString.*\n", value: "")
+    filter(token: ".*@MaskStringMap.*\n", value: "")
     filter(token: ".*@InternalUse.*\n ", value: "")
   }
   file.prune(dir: "../fusionauth-java-client/src/main/java/io/fusionauth/client")

--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2019-2024, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,10 +93,11 @@ target(name: "generateDomain", description: "Generates all of the json files for
   clientLibrary.generateDomainJson(srcDir: "build/src/fusionauth-jwt/io/fusionauth/jwks/domain/", outDir: "src/main/domain")
 
   [
+      "io.fusionauth.api.domain.json.annotation.InternalUse.json",
+      "io.fusionauth.api.domain.json.annotation.MaskString.json",
+      "io.fusionauth.api.domain.json.annotation.MaskStringEntry.json",
       "io.fusionauth.domain.Buildable.json",
       "io.fusionauth.domain.Integration.json",
-      "io.fusionauth.domain.internal.annotation.InternalUse.json",
-      "io.fusionauth.domain.search.AuthenticationKeySearchCriteria.json",
       "io.fusionauth.domain.util.DefaultTools.json",
       "io.fusionauth.domain.util.Normalizer.json",
       "io.fusionauth.domain.util.SQLTools.json",
@@ -171,9 +172,9 @@ target(name: "build-java", description: "Build the Java Client Library") {
     filter(token: "import com.inversoft.mybatis.ExcludeFromJSONColumn;\n", value: "")
     filter(token: "import com.inversoft.mybatis.JSONColumn;\n", value: "")
     filter(token: "import com.inversoft.mybatis.JSONColumnable;\n", value: "")
-    filter(token: "import io.fusionauth.domain.internal.annotation.MaskStringEntry;\n", value: "")
-    filter(token: "import io.fusionauth.domain.internal.annotation.MaskString;\n", value: "")
-    filter(token: "import io.fusionauth.domain.internal.annotation.InternalUse;\n", value: "")
+    filter(token: "import io.fusionauth.api.domain.json.annotation.MaskStringEntry;\n", value: "")
+    filter(token: "import io.fusionauth.api.domain.json.annotation.MaskString;\n", value: "")
+    filter(token: "import io.fusionauth.api.domain.json.annotation.InternalUse;\n", value: "")
     filter(token: ".*@MaskStringEntry\\.List\\(\\{(\\n|.)*\\}\\)\\n", value: "")
     filter(token: ".*@MaskStringEntry\\(.*\n", value: "")
     filter(token: ".*@MaskString.*\n", value: "")

--- a/build.savant
+++ b/build.savant
@@ -51,7 +51,7 @@ project(group: "io.fusionauth", name: "fusionauth-client-builder", version: "1.4
 // Plugins
 clientLibrary = loadPlugin(id: "com.inversoft.savant.plugin:client-library:0.4.1")
 dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.6")
-file = loadPlugin(id: "org.savantbuild.plugin:file:2.0.0-RC.6")
+file = loadPlugin(id: "org.savantbuild.plugin:file:2.0.0-RC.7.{integration}")
 idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")
 release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
 
@@ -162,7 +162,7 @@ target(name: "build-java", description: "Build the Java Client Library") {
 
   file.prune(dir: "../fusionauth-java-client/src/main/java/io/fusionauth/domain")
   file.copy(to: "../fusionauth-java-client/src/main/java/io/fusionauth/domain") {
-    fileSet(dir: "../fusionauth-app/src/main/java/io/fusionauth/domain")
+    fileSet(dir: "../fusionauth-app/src/main/java/io/fusionauth/domain", excludePatterns: ["internal/annotation/*"])
     filter(token: ", JSONColumnable", value: "")
     filter(token: "implements JSONColumnable, ", value: "")
     filter(token: "implements JSONColumnable", value: "")
@@ -171,10 +171,17 @@ target(name: "build-java", description: "Build the Java Client Library") {
     filter(token: "import com.inversoft.mybatis.ExcludeFromJSONColumn;\n", value: "")
     filter(token: "import com.inversoft.mybatis.JSONColumn;\n", value: "")
     filter(token: "import com.inversoft.mybatis.JSONColumnable;\n", value: "")
+    filter(token: "import io.fusionauth.domain.internal.annotation.MaskStringEntry;\n", value: "")
+    filter(token: "import io.fusionauth.domain.internal.annotation.MaskString;\n", value: "")
+    filter(token: "import io.fusionauth.domain.internal.annotation.InternalUse;\n", value: "")
+    filter(token: ".*@MaskStringEntry\\.List\\(\\{(\\n|.)*\\}\\)\\n", value: "")
+    filter(token: ".*@MaskStringEntry\\(.*\n", value: "")
+    filter(token: ".*@MaskString.*\n", value: "")
+    filter(token: ".*@InternalUse.*\n ", value: "")
   }
   file.prune(dir: "../fusionauth-java-client/src/main/java/io/fusionauth/client")
   file.copy(to: "../fusionauth-java-client/src/main/java/io/fusionauth/client") {
-    fileSet(dir: "../fusionauth-app/src/main/java/io/fusionauth/client")
+    fileSet(dir: "../fusionauth-app/src/main/java/io/fusionauth/client", excludePatterns: ["json/internal/*"])
   }
 }
 

--- a/build.savant
+++ b/build.savant
@@ -51,7 +51,7 @@ project(group: "io.fusionauth", name: "fusionauth-client-builder", version: "1.4
 // Plugins
 clientLibrary = loadPlugin(id: "com.inversoft.savant.plugin:client-library:0.4.1")
 dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.6")
-file = loadPlugin(id: "org.savantbuild.plugin:file:2.0.0-RC.7.{integration}")
+file = loadPlugin(id: "org.savantbuild.plugin:file:2.0.0-RC.7")
 idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")
 release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
 

--- a/build.savant
+++ b/build.savant
@@ -96,6 +96,7 @@ target(name: "generateDomain", description: "Generates all of the json files for
       "io.fusionauth.api.domain.annotation.InternalUse.json",
       "io.fusionauth.api.domain.json.annotation.MaskString.json",
       "io.fusionauth.api.domain.json.annotation.MaskStringEntry.json",
+      "io.fusionauth.api.domain.json.annotation.MaskStringMap.json",
       "io.fusionauth.domain.Buildable.json",
       "io.fusionauth.domain.Integration.json",
       "io.fusionauth.domain.util.DefaultTools.json",
@@ -174,6 +175,7 @@ target(name: "build-java", description: "Build the Java Client Library") {
     filter(token: "import com.inversoft.mybatis.JSONColumnable;\n", value: "")
     filter(token: "import io.fusionauth.api.domain.json.annotation.MaskStringEntry;\n", value: "")
     filter(token: "import io.fusionauth.api.domain.json.annotation.MaskString;\n", value: "")
+    filter(token: "import io.fusionauth.api.domain.json.annotation.MaskStringMap;\n", value: "")
     filter(token: "import io.fusionauth.api.domain.json.annotation.InternalUse;\n", value: "")
     filter(token: ".*@MaskStringEntry\\.List\\(\\{(\\n|.)*\\}\\)\\n", value: "")
     filter(token: ".*@MaskStringEntry\\(.*\n", value: "")

--- a/build.savant
+++ b/build.savant
@@ -95,8 +95,7 @@ target(name: "generateDomain", description: "Generates all of the json files for
   [
       "io.fusionauth.api.domain.annotation.InternalUse.json",
       "io.fusionauth.api.domain.json.annotation.MaskString.json",
-      "io.fusionauth.api.domain.json.annotation.MaskStringEntry.json",
-      "io.fusionauth.api.domain.json.annotation.MaskStringMap.json",
+      "io.fusionauth.api.domain.json.annotation.MaskMapValue.json",
       "io.fusionauth.domain.Buildable.json",
       "io.fusionauth.domain.Integration.json",
       "io.fusionauth.domain.util.DefaultTools.json",
@@ -173,14 +172,12 @@ target(name: "build-java", description: "Build the Java Client Library") {
     filter(token: "import com.inversoft.mybatis.ExcludeFromJSONColumn;\n", value: "")
     filter(token: "import com.inversoft.mybatis.JSONColumn;\n", value: "")
     filter(token: "import com.inversoft.mybatis.JSONColumnable;\n", value: "")
-    filter(token: "import io.fusionauth.api.domain.json.annotation.MaskStringEntry;\n", value: "")
+    filter(token: "import io.fusionauth.api.domain.json.annotation.MaskMapValue;\n", value: "")
     filter(token: "import io.fusionauth.api.domain.json.annotation.MaskString;\n", value: "")
-    filter(token: "import io.fusionauth.api.domain.json.annotation.MaskStringMap;\n", value: "")
     filter(token: "import io.fusionauth.api.domain.json.annotation.InternalUse;\n", value: "")
-    filter(token: ".*@MaskStringEntry\\.List\\(\\{(\\n|.)*\\}\\)\\n", value: "")
-    filter(token: ".*@MaskStringEntry\\(.*\n", value: "")
+    filter(token: ".*@MaskMapValue\\.List\\(\\{(\\n|.)*\\}\\)\\n", value: "")
+    filter(token: ".*@MaskMapValue\\(.*\n", value: "")
     filter(token: ".*@MaskString.*\n", value: "")
-    filter(token: ".*@MaskStringMap.*\n", value: "")
     filter(token: ".*@InternalUse.*\n ", value: "")
   }
   file.prune(dir: "../fusionauth-java-client/src/main/java/io/fusionauth/client")

--- a/build.savant
+++ b/build.savant
@@ -93,7 +93,7 @@ target(name: "generateDomain", description: "Generates all of the json files for
   clientLibrary.generateDomainJson(srcDir: "build/src/fusionauth-jwt/io/fusionauth/jwks/domain/", outDir: "src/main/domain")
 
   [
-      "io.fusionauth.api.domain.json.annotation.InternalUse.json",
+      "io.fusionauth.api.domain.annotation.InternalUse.json",
       "io.fusionauth.api.domain.json.annotation.MaskString.json",
       "io.fusionauth.api.domain.json.annotation.MaskStringEntry.json",
       "io.fusionauth.domain.Buildable.json",

--- a/src/main/client/android.client.ftl
+++ b/src/main/client/android.client.ftl
@@ -169,7 +169,7 @@ public class FusionAuthClient {
   * Creates a new copy of this client with the provided tenant Id. When more than one tenant is configured in FusionAuth
   * use this method to set the tenant Id prior to making API calls.
   * <p>
-  * When only one tenant is configured, or you have you have not configured tenants, setting the tenant is not necessary.
+  * When only one tenant is configured, or you have not configured tenants, setting the tenant is not necessary.
   *
   * @param tenantId The tenant Id
   * @return the new FusionAuthClient

--- a/src/main/client/java.client.ftl
+++ b/src/main/client/java.client.ftl
@@ -297,7 +297,7 @@ public class FusionAuthClient {
   * Creates a new copy of this client with the provided tenant Id. When more than one tenant is configured in FusionAuth
   * use this method to set the tenant Id prior to making API calls.
   * <p>
-  * When only one tenant is configured, or you have you have not configured tenants, setting the tenant is not necessary.
+  * When only one tenant is configured, or you have not configured tenants, setting the tenant is not necessary.
   *
   * @param tenantId The tenant Id
   * @return the new FusionAuthClient

--- a/src/main/client/java.client.ftl
+++ b/src/main/client/java.client.ftl
@@ -260,6 +260,8 @@ public class FusionAuthClient {
 
   private final String baseURL;
 
+  private final ObjectMapper customMapper;
+
   private final String tenantId;
 
   public int connectTimeout;
@@ -279,11 +281,16 @@ public class FusionAuthClient {
   }
 
   public FusionAuthClient(String apiKey, String baseURL, int connectTimeout, int readTimeout, String tenantId) {
+    this(apiKey, baseURL, connectTimeout, readTimeout, tenantId, null);
+  }
+
+  public FusionAuthClient(String apiKey, String baseURL, int connectTimeout, int readTimeout, String tenantId, ObjectMapper objectMapper) {
     this.apiKey = apiKey;
     this.baseURL = baseURL;
     this.connectTimeout = connectTimeout;
     this.readTimeout = readTimeout;
     this.tenantId = tenantId;
+    this.customMapper = objectMapper;
   }
 
   /**
@@ -301,6 +308,17 @@ public class FusionAuthClient {
     }
 
     return new FusionAuthClient(apiKey, baseURL, connectTimeout, readTimeout, tenantId.toString());
+  }
+
+  /**
+  * Creates a new copy of this client with the object mapper. This will take the place of the default FusionAuth object mapper when serializing
+  * objects to JSON for the request body
+  *
+  * @param objectMapper The object mapper
+  * @return the new FusionAuthClient
+  */
+  public FusionAuthClient setObjectMapper(ObjectMapper objectMapper) {
+    return new FusionAuthClient(apiKey, baseURL, connectTimeout, readTimeout, tenantId, objectMapper);
   }
 
 [#list apis as api]
@@ -346,7 +364,7 @@ public class FusionAuthClient {
       [#elseif param.type == "urlParameter"]
         .urlParameter("${param.parameterName}", ${(param.constant?? && param.constant)?then(param.value, param.name)})
       [#elseif param.type == "body"]
-        .bodyHandler(new JSONBodyHandler(${param.name}, objectMapper))
+        .bodyHandler(new JSONBodyHandler(${param.name}, objectMapper()))
       [/#if]
     [/#list]
     [#if formPost]
@@ -375,5 +393,9 @@ public class FusionAuthClient {
     }
 
     return client;
+  }
+
+  private ObjectMapper objectMapper() {
+    return customMapper != null ? customMapper : objectMapper;
   }
 }

--- a/src/main/client/java.client.ftl
+++ b/src/main/client/java.client.ftl
@@ -312,7 +312,7 @@ public class FusionAuthClient {
 
   /**
   * Creates a new copy of this client with the object mapper. This will take the place of the default FusionAuth object mapper when serializing
-  * objects to JSON for the request body
+  * and deserializing objects to and from JSON for the request and response bodies.
   *
   * @param objectMapper The object mapper
   * @return the new FusionAuthClient
@@ -382,8 +382,8 @@ public class FusionAuthClient {
 
   protected <T, U> RESTClient<T, U> startAnonymous(Class<T> type, Class<U> errorType) {
     RESTClient<T, U> client = new RESTClient<>(type, errorType)
-        .successResponseHandler(type != Void.TYPE ? new JSONResponseHandler<>(type, objectMapper) : null)
-        .errorResponseHandler(errorType != Void.TYPE ? new JSONResponseHandler<>(errorType, objectMapper) : null)
+        .successResponseHandler(type != Void.TYPE ? new JSONResponseHandler<>(type, objectMapper()) : null)
+        .errorResponseHandler(errorType != Void.TYPE ? new JSONResponseHandler<>(errorType, objectMapper()) : null)
         .url(baseURL)
         .connectTimeout(connectTimeout)
         .readTimeout(readTimeout);

--- a/src/main/domain/io.fusionauth.domain.Entity.json
+++ b/src/main/domain/io.fusionauth.domain.Entity.json
@@ -8,9 +8,9 @@
       "type" : "Entity"
     } ]
   }, {
-    "type" : "Tenantable"
-  }, {
     "type" : "JSONColumnable"
+  }, {
+    "type" : "Tenantable"
   } ],
   "fields" : {
     "data" : {

--- a/src/main/domainNG/io.fusionauth.domain.Entity.json
+++ b/src/main/domainNG/io.fusionauth.domain.Entity.json
@@ -53,7 +53,7 @@
       "type" : "EntityType"
     }
   },
-  "imports" : [ "io.fusionauth.domain.Buildable", "io.fusionauth.domain.Tenantable", "com.inversoft.mybatis.JSONColumnable", "java.util.Map", "java.lang.String", "java.util.UUID", "java.time.ZonedDateTime", "io.fusionauth.domain.EntityType" ],
+  "imports" : [ "io.fusionauth.domain.Buildable", "com.inversoft.mybatis.JSONColumnable", "io.fusionauth.domain.Tenantable", "java.util.Map", "java.lang.String", "java.util.UUID", "java.time.ZonedDateTime", "io.fusionauth.domain.EntityType" ],
   "interfaces" : [ {
     "className" : "io.fusionauth.domain.Buildable",
     "type" : "Buildable",
@@ -62,11 +62,11 @@
       "type" : "Entity"
     } ]
   }, {
-    "className" : "io.fusionauth.domain.Tenantable",
-    "type" : "Tenantable"
-  }, {
     "className" : "com.inversoft.mybatis.JSONColumnable",
     "type" : "JSONColumnable"
+  }, {
+    "className" : "io.fusionauth.domain.Tenantable",
+    "type" : "Tenantable"
   } ],
   "objectType" : "Object",
   "packageName" : "io.fusionauth.domain",


### PR DESCRIPTION
Adds the ability to set a custom object mapper on the java client and updates api call methods to check for the custom mapper before making the call and using that if available.

Update to use the savant copy plugin that now accepts regex so that we can filter out the mask annotations. Also filters out the @InternalUse annotation which looks to have been shipped unintentionally