### PR TITLE
Mcr/netcore allow http client

### DIFF
--- a/src/main/client/netcore.client.ftl
+++ b/src/main/client/netcore.client.ftl
@@ -137,4 +137,22 @@ namespace io.fusionauth {
       return new DefaultRESTClient(host);
     }
   }
+
+  public class HttpClientBuilder : IRESTClientBuilder
+  {
+    public HttpClient HTTP_CLIENT;
+
+    public HttpClientBuilder(HttpClient httpClient)
+    {
+      HTTP_CLIENT = httpClient;
+    }
+
+    public IRESTClient build(string host)
+    {
+      if (HTTP_CLIENT.BaseAddress == null)
+      {
+        HTTP_CLIENT.BaseAddress = new Uri(host);
+      }
+      return new DefaultRESTClient(HTTP_CLIENT);
+    }
 }

--- a/src/main/client/netcore.client.sync.ftl
+++ b/src/main/client/netcore.client.sync.ftl
@@ -50,8 +50,8 @@ namespace io.fusionauth {
   public class FusionAuthSyncClient : IFusionAuthSyncClient {
     public readonly FusionAuthClient client;
 
-    public FusionAuthSyncClient(string apiKey, string host, string tenantId = null) {
-      client = new FusionAuthClient(apiKey, host, tenantId);
+    public FusionAuthSyncClient(string apiKey, string host, string tenantId = null, IRESTClientBuilder clientBuilder = null) {
+      client = new FusionAuthClient(apiKey, host, tenantId, clientBuilder);
     }
 
     /**


### PR DESCRIPTION
Changes needed to ensure [these changes](https://github.com/FusionAuth/fusionauth-netcore-client/pull/71) for the netcore library remain on rebuild. Basically, allowing the acceptance of a httpClient. Issue 19 in (fusionauth-netcore-client)[https://github.com/FusionAuth/fusionauth-netcore-client/issues/19].