### PR TITLE
Adding discriminator field to the IdentityProviderField spec

### DIFF
--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -95,8 +95,14 @@ end
 def add_identity_provider_field(schemas, identity_providers)
   schemas["IdentityProviderField"] = {}
   schemas["IdentityProviderField"]["oneOf"] = []
+  schemas["IdentityProviderField"]["discriminator"] = {
+    "propertyName" => "type",
+    "mapping" => {}
+  }
   identity_providers.each do |idp|
-    schemas["IdentityProviderField"]["oneOf"] << {"$ref" => make_ref(idp) }
+    ref = make_ref(idp)
+    schemas["IdentityProviderField"]["oneOf"] << {"$ref" => ref }
+    schemas["IdentityProviderField"]["discriminator"]["mapping"][idp.sub("IdentityProvider","")] = ref
   end
 end
 


### PR DESCRIPTION
Adding a `type` discriminator to the `IdentityProviderField` input to better handle automatic generation of our client libraries.