### PR TITLE
sort the schemas so diffing is easier

### DIFF
--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -671,7 +671,7 @@ schemas["ZoneId"]["type"] = "string"
 
 add_identity_provider_field(schemas, identity_providers)
 
-components["schemas"] = schemas
+components["schemas"] = schemas.sort.to_h
 
 # add our security schemes
 components["securitySchemes"] = {}


### PR DESCRIPTION
Previously the schema objects would be added according to hash order

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206748044939406