### PR TITLE
Generate domain for completion token TTL

### DIFF
--- a/src/main/domain/io.fusionauth.domain.ExternalIdentifierConfiguration.json
+++ b/src/main/domain/io.fusionauth.domain.ExternalIdentifierConfiguration.json
@@ -18,9 +18,6 @@
     "changePasswordIdTimeToLiveInSeconds" : {
       "type" : "int"
     },
-    "completionTokenTimeToLiveInSeconds" : {
-      "type" : "int"
-    },
     "deviceCodeTimeToLiveInSeconds" : {
       "type" : "int"
     },
@@ -37,6 +34,9 @@
       "type" : "SecureGeneratorConfiguration"
     },
     "externalAuthenticationIdTimeToLiveInSeconds" : {
+      "type" : "int"
+    },
+    "loginIntentTimeToLiveInSeconds" : {
       "type" : "int"
     },
     "oneTimePasswordTimeToLiveInSeconds" : {

--- a/src/main/domain/io.fusionauth.domain.ExternalIdentifierConfiguration.json
+++ b/src/main/domain/io.fusionauth.domain.ExternalIdentifierConfiguration.json
@@ -18,6 +18,9 @@
     "changePasswordIdTimeToLiveInSeconds" : {
       "type" : "int"
     },
+    "completionTokenTimeToLiveInSeconds" : {
+      "type" : "int"
+    },
     "deviceCodeTimeToLiveInSeconds" : {
       "type" : "int"
     },


### PR DESCRIPTION
### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2736
- https://linear.app/fusionauth/issue/ENG-988/[bug]-cannot-log-in-anymore-after-upgrade-to-v150x

### Changes
Adds tenant external Id configuration for completion token TTL.

### Depends on
- https://github.com/FusionAuth/fusionauth-app/pull/452