### PR TITLE
add missing type

### DIFF
--- a/src/main/client/go.domain.ftl
+++ b/src/main/client/go.domain.ftl
@@ -102,6 +102,8 @@ func (b *BaseHTTPResponse) SetStatus(status int) {
   b.StatusCode = status
 }
 
+type LinkedHashMap map[string]interface{}
+
 [#assign ignoredTypes = ["HTTPHeaders","IntrospectResponse","LocalizedIntegers","LocalizedStrings","UserinfoResponse","ApplicationEvent"]/]
 [#list domain as d]
   [#if !(ignoredTypes?seq_contains(d.type))]


### PR DESCRIPTION
Add missing type for the `StatusResponse` which extends `LinkedHashMap` on the java side of the world. 

### Related
- https://github.com/FusionAuth/go-client/pull/83
- https://github.com/FusionAuth/go-client/issues/82
- https://github.com/FusionAuth/fusionauth-client-builder/pull/88