### PR TITLE
Add `Buildable` interface to `GroupMemberSearchCriteria`

### DIFF
--- a/src/main/domain/io.fusionauth.domain.search.GroupMemberSearchCriteria.json
+++ b/src/main/domain/io.fusionauth.domain.search.GroupMemberSearchCriteria.json
@@ -5,6 +5,12 @@
   "extends" : [ {
     "type" : "BaseSearchCriteria"
   } ],
+  "implements" : [ {
+    "type" : "Buildable",
+    "typeArguments" : [ {
+      "type" : "GroupMemberSearchCriteria"
+    } ]
+  } ],
   "fields" : {
     "groupId" : {
       "type" : "UUID"


### PR DESCRIPTION
### Issue
- [ENG-1600: SCIM Groups resource API is non-atomic](https://linear.app/fusionauth/issue/ENG-1600/scim-groups-resource-api-is-non-atomic)
- https://github.com/FusionAuth/fusionauth-issues/issues/2869

Related PR
- https://github.com/FusionAuth/fusionauth-app/pull/553