### PR TITLE
Add support for encrypted SAML assertions as Service Provider

### DIFF
--- a/src/main/domain/io.fusionauth.domain.provider.BaseSAMLv2IdentityProvider.json
+++ b/src/main/domain/io.fusionauth.domain.provider.BaseSAMLv2IdentityProvider.json
@@ -15,6 +15,9 @@
     } ]
   } ],
   "fields" : {
+    "assertionDecryptionConfiguration" : {
+      "type" : "SAMLv2AssertionDecryptionConfiguration"
+    },
     "emailClaim" : {
       "type" : "String"
     },

--- a/src/main/domain/io.fusionauth.domain.provider.SAMLv2AssertionDecryptionConfiguration.json
+++ b/src/main/domain/io.fusionauth.domain.provider.SAMLv2AssertionDecryptionConfiguration.json
@@ -1,0 +1,13 @@
+{
+  "packageName" : "io.fusionauth.domain.provider",
+  "type" : "SAMLv2AssertionDecryptionConfiguration",
+  "description" : "/**\n * Config for encrypted assertions when acting as SAML SP\n *\n * @author Jaret Hendrickson\n */\n",
+  "extends" : [ {
+    "type" : "Enableable"
+  } ],
+  "fields" : {
+    "keyTransportDecryptionKeyId" : {
+      "type" : "UUID"
+    }
+  }
+}

--- a/src/main/domain/io.fusionauth.domain.provider.SAMLv2AssertionDecryptionConfiguration.json
+++ b/src/main/domain/io.fusionauth.domain.provider.SAMLv2AssertionDecryptionConfiguration.json
@@ -1,7 +1,7 @@
 {
   "packageName" : "io.fusionauth.domain.provider",
   "type" : "SAMLv2AssertionDecryptionConfiguration",
-  "description" : "/**\n * Config for encrypted assertions when acting as SAML SP\n *\n * @author Jaret Hendrickson\n */\n",
+  "description" : "/**\n * Configuration for encrypted assertions when acting as SAML Service Provider\n *\n * @author Jaret Hendrickson\n */\n",
   "extends" : [ {
     "type" : "Enableable"
   } ],

--- a/src/main/domainNG/io.fusionauth.domain.search.GroupMemberSearchCriteria.json
+++ b/src/main/domainNG/io.fusionauth.domain.search.GroupMemberSearchCriteria.json
@@ -1,6 +1,9 @@
 {
   "className" : "io.fusionauth.domain.search.GroupMemberSearchCriteria",
-  "extends" : { },
+  "extends" : {
+    "className" : "io.fusionauth.domain.search.BaseSearchCriteria",
+    "type" : "BaseSearchCriteria"
+  },
   "fields" : {
     "SortableFields" : {
       "className" : "java.util.Map",
@@ -26,8 +29,15 @@
       "type" : "UUID"
     }
   },
-  "imports" : [ "java.util.Map", "java.lang.String", "java.util.UUID" ],
-  "interfaces" : [ ],
+  "imports" : [ "io.fusionauth.domain.search.BaseSearchCriteria", "io.fusionauth.domain.Buildable", "java.util.Map", "java.lang.String", "java.util.UUID" ],
+  "interfaces" : [ {
+    "className" : "io.fusionauth.domain.Buildable",
+    "type" : "Buildable",
+    "typeArguments" : [ {
+      "className" : "io.fusionauth.domain.search.GroupMemberSearchCriteria",
+      "type" : "GroupMemberSearchCriteria"
+    } ]
+  } ],
   "objectType" : "Object",
   "packageName" : "io.fusionauth.domain.search",
   "type" : "GroupMemberSearchCriteria"


### PR DESCRIPTION
### Issue:
- https://linear.app/fusionauth/issue/ENG-13/support-saml-assertion-encryption-as-sp
- https://github.com/FusionAuth/fusionauth-issues/issues/2378

### Problem:
FusionAuth does not support receiving encrypted SAML Assertions from an external IdP.

### Solution:
Support encrypted assertions as the SP in a similar manner to acting as the SAML IdP.

### Linked PR:
- https://github.com/FusionAuth/fusionauth-app/pull/630