### PR TITLE
Update APIKey json to include expirationInstant

### DIFF
--- a/src/main/domain/io.fusionauth.domain.APIKey.json
+++ b/src/main/domain/io.fusionauth.domain.APIKey.json
@@ -9,6 +9,9 @@
     } ]
   } ],
   "fields" : {
+    "expirationInstant" : {
+        "type" : "ZonedDateTime"
+    },
     "id" : {
       "type" : "UUID"
     },

--- a/src/main/domainNG/io.fusionauth.domain.APIKey.json
+++ b/src/main/domainNG/io.fusionauth.domain.APIKey.json
@@ -5,6 +5,10 @@
     "type" : "Object"
   },
   "fields" : {
+    "expirationInstant" : {
+      "className" : "java.time.ZonedDateTime",
+      "type" : "ZonedDateTime"
+    },
     "id" : {
       "className" : "java.util.UUID",
       "type" : "UUID"


### PR DESCRIPTION
### Issue: 
- https://linear.app/fusionauth/issue/ENG-681/make-api-keys-more-secure-by-adding-an-expiration-time-to-them
- https://github.com/FusionAuth/fusionauth-issues/issues/2537

### Problem: 
Currently, once an API key is created, it lives forever. The only option a user has for deactivating or expiring an API key is to delete it manually via the Admin App or API. To help promote security best practices around API key usage, a user should have the option to add an expiration to an API key.

### Solution:
Updated the APIKey domain model to include an `expirationInstant` field. This field represents the instant the associated API expires.  