### PR TITLE
fix the open api gen script

### DIFF
--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -1,17 +1,3 @@
-# Copyright (c) 2025, FusionAuth, All Rights Reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 #!/usr/bin/env ruby
 
 require 'json'

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -319,14 +319,6 @@ def process_rawpaths(rawpaths, options)
 end
 
 def process_api_file(fn, paths, options, deferred)
-  # If the file name contains DisplayableRawLogin log all the params to console
-  # if fn.include?("DisplayableRawLogin")
-  #   puts "Processing file: #{fn}"
-  #   json["params"].each do |param|
-  #     puts "Param name: #{param['name']}, Param type: #{param['type']}"
-  #   end
-  # end
-
   if options[:verbose] 
     puts "processing "+fn
   end

--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -187,7 +187,7 @@ def process_domain_file(fn, schemas, options, identity_providers, domain_files)
     type = ex["type"]
 
     #  Search domain_files for a file that matches *\.type.json exactly
-    file = domain_files.find { |file| file.match(/\.#{type}\.json$/) }
+    file = domain_files.find { |file| file.end_with?(".#{type}.json") }
     if file
       ef = File.open(file)
       efs = ef.read


### PR DESCRIPTION
So what was happening was the regex to find the files of the classes that any given class extends would cause a mismatch, `io.fusionauth.domain.*"+ex["type"]+".json"`, in particular with that wildcard before the type, I think was intended to handle things that extend from the sub packages of `domain`, things like events, but it would mistakenly pick up the file being parsed instead, or just the wrong one. See example: `DisplayableRawLogin` vs `RawLogin`. And because the order of that fuzzy matching was not guaranteed it also explains the inconsistent behavior.

I made it find a more "exact" match by not using the wildcard and instead working on the list of files already loaded (as long as we don't modify it).

Ideally the json itself would have the package of the extends in addition to simple class name, but I was trying to fight making savant, kotlin, and Intellij all git along while working through the JavaParser lib... and punted and took the easy way out. If I touch that thing again I am just going to transform it from kotlin to Java...