### PR TITLE
feat(openapi): merge request body, support form urlencoded parameters

### DIFF
--- a/bin/build-openapi-yaml.rb
+++ b/bin/build-openapi-yaml.rb
@@ -437,12 +437,45 @@ def merge_operations(new_api_object, old_api_object, uri, method)
   #remove dups
   new_api_object["parameters"] = new_api_object["parameters"].uniq { |p| p["name"] }
 
-  # make sure if we have a requestBody, we pass that along in the merge. This will blow up if we have two operations that take request bodies but don't have the same request body
-  if old_api_object["requestBody"] && !new_api_object["requestBody"]
-    new_api_object["requestBody"] = old_api_object["requestBody"]
+  request_body = merge_request_bodies(new_api_object, old_api_object)
+  new_api_object["requestBody"] = request_body if request_body
+
+  new_api_object
+end
+
+def merge_request_bodies(new_api_object, old_api_object)
+  return if !new_api_object["requestBody"] && !old_api_object["requestBody"]
+
+  # if there is no request body defined on the new API, mark the current request body as not required
+  unless new_api_object["requestBody"]
+    return { "required" => false, "content" => old_api_object["requestBody"]["content"] }
   end
 
-  return new_api_object
+  request_body = { "content" => {} }
+
+  # if the old API does not have a request body, mark it as not required
+  if old_api_object["requestBody"]
+    request_body["content"] = old_api_object["requestBody"]["content"]
+  else
+    return { "required" => false, "content" => new_api_object["requestBody"]["content"] }
+  end
+
+  # Merge new request bodies into definition
+  new_api_object["requestBody"]["content"].each do |media_type, media_type_definition|
+    # if there is no request body for the media_type defined, just set it
+    unless request_body["content"][media_type]
+      request_body["content"][media_type] = media_type_definition
+      break
+    end
+
+    # if there is already a oneOf node, wrap the current schema
+    unless request_body["content"][media_type]["schema"].key?("oneOf")
+      request_body["content"][media_type]["schema"] = { "oneOf" => [request_body["content"][media_type]["schema"]] }
+    end
+    request_body["content"][media_type]["schema"]["oneOf"] << media_type_definition["schema"]
+  end
+
+  request_body
 end
 
 def build_path(uri, json, paths, include_optional_segment_param, options)


### PR DESCRIPTION
This commit introduces two new features to improve the OpenAPI generation process.  

1. It adds logic to merge request bodies when combining multiple API definitions. This ensures that request bodies from both old and new API objects are properly merged, handling scenarios where they use different media types or schemas. For conflicting schemas, a `oneOf` node is utilized to allow multiple schema variations in a compatible manner.
2. It enhances support for form-encoded parameters by including them in the OpenAPI request body. If form parameters are present, they are added under the `application/x-www-form-urlencoded` content type, alongside any existing JSON body parameters, with their schema automatically generated.