### PR TITLE
add missing operations

### DIFF
--- a/src/main/api/patchEntityTypePermission.json
+++ b/src/main/api/patchEntityTypePermission.json
@@ -1,0 +1,42 @@
+{
+  "uri": "/api/entity/type",
+  "comments": [
+    "Patches the permission with the given Id for the entity type."
+  ],
+  "method": "patch",
+  "methodName": "patchEntityTypePermission",
+  "successResponse": "EntityTypeResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "entityTypeId",
+      "comments": [
+        "The Id of the entityType that the permission belongs to."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "permission",
+      "constant": true,
+      "type": "urlSegment",
+      "value": "\"permission\""
+    },
+    {
+      "name": "permissionId",
+      "comments": [
+        "The Id of the permission to patch."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request that contains the new permission information."
+      ],
+      "type": "body",
+      "javaType": "EntityTypeRequest"
+    }
+  ]
+}

--- a/src/main/api/patchForm.json
+++ b/src/main/api/patchForm.json
@@ -1,0 +1,28 @@
+{
+  "uri": "/api/form",
+  "comments": [
+    "Patches the form with the given Id."
+  ],
+  "method": "patch",
+  "methodName": "patchForm",
+  "successResponse": "FormResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "formId",
+      "comments": [
+        "The Id of the form to patch."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request object that contains the new form information."
+      ],
+      "type": "body",
+      "javaType": "FormRequest"
+    }
+  ]
+}

--- a/src/main/api/patchFormField.json
+++ b/src/main/api/patchFormField.json
@@ -1,0 +1,28 @@
+{
+  "uri": "/api/form/field",
+  "comments": [
+    "Patches the form field with the given Id."
+  ],
+  "method": "patch",
+  "methodName": "patchFormField",
+  "successResponse": "FormFieldResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "fieldId",
+      "comments": [
+        "The Id of the form field to patch."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request object that contains the new form field information."
+      ],
+      "type": "body",
+      "javaType": "FormFieldRequest"
+    }
+  ]
+}

--- a/src/main/api/patchIPAccessControlList.json
+++ b/src/main/api/patchIPAccessControlList.json
@@ -1,0 +1,28 @@
+{
+  "uri": "/api/ip-acl",
+  "comments": [
+    "Update the IP Access Control List with the given Id."
+  ],
+  "method": "patch",
+  "methodName": "patchIPAccessControlList",
+  "successResponse": "IPAccessControlListResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "accessControlListId",
+      "comments": [
+        "The Id of the IP Access Control List to patch."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request that contains the new IP Access Control List information."
+      ],
+      "type": "body",
+      "javaType": "IPAccessControlListRequest"
+    }
+  ]
+}

--- a/src/main/api/patchWebhook.json
+++ b/src/main/api/patchWebhook.json
@@ -1,0 +1,28 @@
+{
+  "uri": "/api/webhook",
+  "comments": [
+    "Patches the webhook with the given Id."
+  ],
+  "method": "patch",
+  "methodName": "patchWebhook",
+  "successResponse": "WebhookResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "webhookId",
+      "comments": [
+        "The Id of the webhook to update."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request that contains the new webhook information."
+      ],
+      "type": "body",
+      "javaType": "WebhookRequest"
+    }
+  ]
+}

--- a/src/main/api/updateFamily.json
+++ b/src/main/api/updateFamily.json
@@ -1,0 +1,28 @@
+{
+  "uri": "/api/user/family",
+  "comments": [
+    "Updates a family with a given Id."
+  ],
+  "method": "put",
+  "methodName": "updateFamily",
+  "successResponse": "FamilyResponse",
+  "errorResponse": "Errors",
+  "params": [
+    {
+      "name": "familyId",
+      "comments": [
+         "The Id of the family to update."
+      ],
+      "type": "urlSegment",
+      "javaType": "UUID"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The request object that contains all the new family information."
+      ],
+      "type": "body",
+      "javaType": "FamilyRequest"
+    }
+  ]
+}


### PR DESCRIPTION
This is split out from https://github.com/FusionAuth/fusionauth-client-builder/pull/123

It does not include the github action to check for missing operations going forward, only brings in the ones that I found

Internal: https://inversoft.slack.com/archives/C0407G6V5/p1743435569037359