### PR TITLE
Merge bhalsey/ENG-2184/sorted_domain_order

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -50,7 +50,7 @@ project(group: "io.fusionauth", name: "fusionauth-client-builder", version: "1.5
 }
 
 // Plugins
-clientLibrary = loadPlugin(id: "com.inversoft.savant.plugin:client-library:0.4.2")
+clientLibrary = loadPlugin(id: "com.inversoft.savant.plugin:client-library:0.4.4")
 dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0")
 file = loadPlugin(id: "org.savantbuild.plugin:file:2.0.0")
 idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0")


### PR DESCRIPTION
### Issue:
- https://linear.app/fusionauth/issue/ENG-2184/client-code-generation-is-non-deterministic

### Problem:
Every time we touch domain objects, the go and typescript clients get generated in a different order. This makes it impossible to determine what changed in client PRs. Furthermore, the order for a pegged version can vary from one developer to another.

This is a result of the domain objects getting loaded in from directory lists. The client generating freemarker then uses code like `[#list domain as d]` to iterate over them.

### Solution:
Use the updated client builder, which sorts the domain objects by their "class" name (the last real name in a file like `io.fusionauth.domain.Tenant.json`

### Linked PR:
- https://github.com/inversoft/client-library-plugin/pull/3
- https://github.com/inversoft/client-library-plugin/pull/5

### Reviewer Notes:
We still have an issue with openapi.yaml. That is built with a ruby script and is not affected by this change.
