### PR TITLE
add api method to change password using JWT

### DIFF
--- a/src/main/api/changePasswordJWT.json
+++ b/src/main/api/changePasswordJWT.json
@@ -1,0 +1,33 @@
+{
+  "uri": "/api/user/change-password",
+  "comments": [
+    "Changes a user's password using their access token (JWT) instead of the changePasswordId",
+    "A common use case for this method will be if you want to allow the user to change their own password.",
+    "",
+    "Remember to send refreshToken in the request body if you want to get a new refresh token when login using the returned oneTimePassword."
+  ],
+    "method": "post",
+  "methodName": "changePasswordByJWT",
+  "successResponse": "ChangePasswordResponse",
+  "errorResponse": "Errors",
+  "anonymous": true,
+  "authorization": "\"Bearer \" + encodedJWT",
+  "params": [
+    {
+      "name": "encodedJWT",
+      "comments": [
+        "The encoded JWT (access token)."
+      ],
+      "type": "notUsed",
+      "javaType": "String"
+    },
+    {
+      "name": "request",
+      "comments": [
+        "The change password request that contains all the information used to change the password."
+      ],
+      "type": "body",
+      "javaType": "ChangePasswordRequest"
+    }
+  ]
+}


### PR DESCRIPTION
This PR fixes #141.

First of all, I apologize if this is not the proper way to open a PR.

My goal is to add support for changing passwords using JWT (access token). 

The API doc is [here](https://fusionauth.io/docs/apis/users#change-a-users-password).

I created the API file mixing [checkChangePasswordUsingJWT](https://github.com/mgrunberg/fusionauth-client-builder/blob/develop/src/main/api/checkChangePasswordUsingJWT.json), [changePasswordLoginId](https://github.com/mgrunberg/fusionauth-client-builder/blob/develop/src/main/api/changePasswordLoginId.json), and [changePassword](https://github.com/FusionAuth/fusionauth-client-builder/blob/develop/src/main/api/changePassword.json)