### PR TITLE
Better to run domainDSLBuilder after other cleanup

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -88,12 +88,6 @@ target(name: "generateDomain", description: "Generates all of the json files for
   clientLibrary.generateDomainJson(srcDir: "build/src/fusionauth-jwt/io/fusionauth/jwt/domain/", outDir: "src/main/domain")
   clientLibrary.generateDomainJson(srcDir: "build/src/fusionauth-jwt/io/fusionauth/jwks/domain/", outDir: "src/main/domain")
 
-  // Run the DomainDSLBuilder as well, ideally we would try and switch to this DSL to build the domain objects at some point.
-  // - The DomainDSLBuilder uses ASM the goal is to build a more complete DSL so we can optionally collapse extensions and polymorphic
-  //   classes in order to simplify all client domains that we build. For example some languages don't support polymorphic classes,
-  //   and it also complicates Deserialization for our IdPs etc. Simplifying of collapsing the domain may be useful.
-  domainDSLBuilder()
-
   // Note this is fairly brittle because if the class moves this doesn't get updated.
   [
       "io.fusionauth.api.domain.annotation.InternalUse.json",
@@ -112,6 +106,12 @@ target(name: "generateDomain", description: "Generates all of the json files for
       "io.fusionauth.jwt.domain.Type.json"
   ]
       .forEach({ Files.deleteIfExists(Paths.get("src/main/domain").resolve(it)) })
+
+  // Run the DomainDSLBuilder as well, ideally we would try and switch to this DSL to build the domain objects at some point.
+  // - The DomainDSLBuilder uses ASM the goal is to build a more complete DSL so we can optionally collapse extensions and polymorphic
+  //   classes in order to simplify all client domains that we build. For example some languages don't support polymorphic classes,
+  //   and it also complicates Deserialization for our IdPs etc. Simplifying of collapsing the domain may be useful.
+  domainDSLBuilder()
 }
 
 target(name: "idea", description: "Updates the IntelliJ IDEA module file") {


### PR DESCRIPTION
### Summary 
Not really a bug, but an improvement in ordering. 

In the vent that the domainDSLBuilder fails for any reason, it is better if we do this after we do cleanup on the `src/main/domain` files so we don't have files hanging around that would otherwise get cleaned up.